### PR TITLE
make seed setting a command line option

### DIFF
--- a/__main__.py
+++ b/__main__.py
@@ -1,7 +1,7 @@
 import argparse
-import sys
 
 def train(args):
+    set_seed(args.seed)
     import train
     train.main(args)
 
@@ -13,6 +13,15 @@ def score(args):
     import score
     score.main(args)
 
+def set_seed(seed_value):
+    if seed_value is None:
+        return
+    print('Setting deepQuest seed to', seed_value)
+    import numpy.random
+    numpy.random.seed(seed_value)
+    import random
+    random.seed(seed_value)
+
 if __name__ == "__main__":
     parser = argparse.ArgumentParser("A framework for neural-based quality estimation for machine translation. ")
     subparsers = parser.add_subparsers(help='train '
@@ -23,7 +32,8 @@ if __name__ == "__main__":
     train_parser = subparsers.add_parser('train', help='Train QE models')
     train_parser.set_defaults(func=train)
     train_parser.add_argument("-c", "--config",   required=False, help="Config YAML or pkl for loading the model configuration. ")
-    train_parser.add_argument("-ds", "--dataset", required=False, help="Dataset instance with data")
+    train_parser.add_argument("-ds", "--dataset", required=False, help="Dataset instance with data. ")
+    train_parser.add_argument("-s", "--seed", type=int, default=None, required=False, help="Value to set seed for deterministic results. ")
     train_parser.add_argument("changes", nargs="*", help="Changes to config. "
                                                    "Following the syntax Key=Value",
                                                     default="")

--- a/configs/config-doc-BiRNN.yml
+++ b/configs/config-doc-BiRNN.yml
@@ -4,6 +4,8 @@ SRC_LAN: 'src'                                     # Language of the source text
 TRG_LAN: 'mt'                                      # Language of the target text
 # SRC_LAN or TRG_LAN are expected to be the file extensions of the data files
 
+SEED: 1                                            # Value to set seed for deterministic results. (omit for random results)
+
 OUTPUTS_IDS_DATASET: ['doc_qe']
 OUTPUTS_IDS_MODEL: ['doc_qe']
 

--- a/configs/config-sent-BiRNN.yml
+++ b/configs/config-sent-BiRNN.yml
@@ -4,6 +4,8 @@ SRC_LAN: 'src'                                     # Language of the source text
 TRG_LAN: 'mt'                                      # Language of the target text
 # SRC_LAN or TRG_LAN are expected to be the file extensions of the data files
 
+SEED: 1                                            # Value to set seed for deterministic results. (omit for random results)
+
 OUTPUTS_IDS_DATASET: ['sent_qe']
 OUTPUTS_IDS_MODEL: ['sent_qe']
 

--- a/configs/config-word-BiRNN.yml
+++ b/configs/config-word-BiRNN.yml
@@ -4,6 +4,8 @@ SRC_LAN: 'src'                                     # Language of the source text
 TRG_LAN: 'mt'                                      # Language of the target text
 # SRC_LAN or TRG_LAN are expected to be the file extensions of the data files
 
+SEED: 1                                            # Value to set seed for deterministic results. (omit for random results)
+
 OUTPUTS_IDS_DATASET: ['word_qe']
 OUTPUTS_IDS_MODEL: ['word_qe']
 

--- a/configs/default-config-BiRNN.yml
+++ b/configs/default-config-BiRNN.yml
@@ -12,6 +12,8 @@ WORD_QE_CLASSES: 5
 #OUTPUTS_IDS_DATASET_FULL: ['target_text', 'word_qe', 'sent_hter']   # Corresponding outputs of the dataset #UNUSED?
 #OUTPUTS_IDS_MODEL_FULL: ['target_text','word_qe', 'sent_hter']      # Corresponding outputs of the built model #UNUSED
 
+MODEL_DIRECTORY: 'trained_models/'                # Trained models will be stored here
+DATASET_STORE_PATH: 'datasets/'                   # Dataset instance will be stored here
 
 #EVAL_ON_SETS_KERAS: ['val']                 # Possible values: 'train', 'val' and 'test' (Keras' evaluator). Untested.
 EVAL_ON_SETS_KERAS: []
@@ -205,8 +207,6 @@ USE_PRELU: False                             # use PReLU activations as regulari
 USE_L2: False                                # L2 normalization on the features
 
 DOUBLE_STOCHASTIC_ATTENTION_REG: 0.0         # Doubly stochastic attention (Eq. 14 from arXiv:1502.03044)
-
-DATASET_STORE_PATH: 'datasets/'                   # Dataset instance will be stored here
 
 SAMPLING_SAVE_MODE: 'listoflists'                        # 'list': Store in a text file, one sentence per line.
 VERBOSE: 1                                        # Verbosity level

--- a/predict.py
+++ b/predict.py
@@ -1,5 +1,6 @@
 # This predict script doesn't work yet -- drj 2019-09
 
+#Seed fixing must happen before anything else is loaded
 import ast
 import os
 import re
@@ -10,13 +11,11 @@ import pickle
 from data_engine.prepare_data import build_dataset, update_dataset_from_file, keep_n_captions
 from keras_wrapper.cnn_model import loadModel, updateModel
 from keras_wrapper.dataset import loadDataset, saveDataset
-from dq_utils.callbacks import *
 from nmt_keras.model_zoo import TranslationModel
 from utils.utils import update_parameters
 from keras.utils import CustomObjectScope
 
-from numpy.random import seed
-
+from dq_utils.callbacks import *
 import nmt_keras.models as modFactory
 import nmt_keras.dq_evaluation as dq_evaluation
 
@@ -246,10 +245,6 @@ def main(args):
     if args.save_path is None:
         args.save_path = parameters['STORE_PATH']
 
-    rnd_seed = parameters.get('RND_SEED', None)
-    if rnd_seed != None:
-        seed(rnd_seed)
-
     logging.info('Running sampling.')
 
     # NMT Keras expects model path to appear without the .h5
@@ -270,6 +265,3 @@ def main(args):
         apply_NMT_model(parameters, args)
 
     logging.info('Done.')
-
-if __name__ == "__main__":
-    main()

--- a/score.py
+++ b/score.py
@@ -34,6 +34,3 @@ def main(args):
     print('Mean absolute error: %.3f' % mae)
     print('Pearsons correlation: %.3f' % pcc)
     print('RMSE: %.3f' % rmse)
-
-if __name__ == "__main__":
-    sys.exit(main(args))

--- a/train.py
+++ b/train.py
@@ -1,13 +1,6 @@
 # -*- coding: utf-8 -*-
 from __future__ import print_function
 
-from numpy.random import seed
-seed(1)
-
-import random
-random.seed(1)
-del random
-
 import ast
 import glob
 import logging
@@ -19,15 +12,13 @@ import yaml
 
 from keras_wrapper.extra.read_write import pkl2dict, dict2pkl
 from keras_wrapper.extra.read_write import pkl2dict, dict2pkl
-
-from dq_utils.datatools import preprocessDoc
-
 from data_engine.prepare_data import build_dataset, update_dataset_from_file, keep_n_captions
 from nmt_keras import check_params
 from nmt_keras.callbacks import PrintPerformanceMetricOnEpochEndOrEachNUpdates
 from nmt_keras.training import train_model
 from utils.utils import update_parameters
 
+from dq_utils.datatools import preprocessDoc
 import nmt_keras.models as modFactory
 
 logging.basicConfig(level=logging.INFO, format='[%(asctime)s] %(message)s', datefmt='%d/%m/%Y %H:%M:%S')
@@ -463,6 +454,3 @@ def main(args):
 
 
     logger.info('Done!')
-
-if __name__ == "__main__":
-    sys.exit(main(args))

--- a/utils/test-BiRNNdoc.sh
+++ b/utils/test-BiRNNdoc.sh
@@ -16,7 +16,7 @@ TESTVAL=$(awk -v backend=$KERAS_BACKEND -v level=$level -v task_name=$task_name 
 
 python utils/getTestData_BiRNNdoc.py
 
-PYTHONHASHSEED=0 python __main__.py train -c ${conf} TASK_NAME=$task_name DATASET_NAME=$task_name MODEL_TYPE=$model_type MODEL_NAME=$model_name || true > log-${model_name}-test.txt
+python __main__.py train -s 1 -c ${conf} TASK_NAME=$task_name DATASET_NAME=$task_name MODEL_TYPE=$model_type MODEL_NAME=$model_name || true > log-${model_name}-test.txt
 
 PCC=$(awk -F, '/pearson/ {M=-1;next};$3>M {M=$3};END {print M}' trained_models/${task_name}_srcmt_${model_type}/val.qe_metrics)
 
@@ -30,7 +30,7 @@ else
   TRAIN_RESULT="passed"
   echo "QE training $TRAIN_RESULT ($level  level BiRNN with $KERAS_BACKEND on $task_name test dataset)"
   EPOCH=$(awk -F, '/pearson/ {M=-1;next};$3>M {M=$3;E=$1};END {print E}' trained_models/${task_name}_srcmt_${model_type}/val.qe_metrics)
-  PYTHONHASHSEED=0 python __main__.py predict --dataset datasets/Dataset_${task_name}_srcmt.pkl --model trained_models/${model_name}/epoch_${EPOCH}.h5 --save_path saved_predictions/prediction_${task_name}/ --evalset test
+  python __main__.py predict --dataset datasets/Dataset_${task_name}_srcmt.pkl --model trained_models/${model_name}/epoch_${EPOCH}.h5 --save_path saved_predictions/prediction_${task_name}/ --evalset test
   PCC=$(awk -F, '/pearson/ {M=-1;next};$3>M {M=$3};END {print M}' saved_predictions/prediction_${task_name}/test.qe_metrics)
   TESTVAL=$(awk -v backend=$KERAS_BACKEND -v level=${level}Predict -v task_name=$task_name -v metric=$metric -F,\
    'NR==1 {next};$1==backend && $2==level && $3==task_name && $4==metric {M=$5};END {print M}' utils/testVals.csv )

--- a/utils/test-BiRNNdoc.sh
+++ b/utils/test-BiRNNdoc.sh
@@ -16,7 +16,7 @@ TESTVAL=$(awk -v backend=$KERAS_BACKEND -v level=$level -v task_name=$task_name 
 
 python utils/getTestData_BiRNNdoc.py
 
-python __main__.py train -s 1 -c ${conf} TASK_NAME=$task_name DATASET_NAME=$task_name MODEL_TYPE=$model_type MODEL_NAME=$model_name || true > log-${model_name}-test.txt
+python __main__.py train -c ${conf} TASK_NAME=$task_name DATASET_NAME=$task_name MODEL_TYPE=$model_type MODEL_NAME=$model_name || true > log-${model_name}-test.txt
 
 PCC=$(awk -F, '/pearson/ {M=-1;next};$3>M {M=$3};END {print M}' trained_models/${task_name}_srcmt_${model_type}/val.qe_metrics)
 

--- a/utils/test-BiRNNsent.sh
+++ b/utils/test-BiRNNsent.sh
@@ -16,7 +16,7 @@ TESTVAL=$(awk -v backend=$KERAS_BACKEND -v level=$level -v task_name=$task_name 
 
 python utils/getTestData_BiRNNsent.py
 
-python __main__.py train -s 1 -c ${conf} TASK_NAME=$task_name DATASET_NAME=$task_name MODEL_TYPE=$model_type MODEL_NAME=$model_name || true > log-${model_name}-test.txt
+python __main__.py train -c ${conf} TASK_NAME=$task_name DATASET_NAME=$task_name MODEL_TYPE=$model_type MODEL_NAME=$model_name || true > log-${model_name}-test.txt
 
 PCC=$(awk -F, '/pearson/ {M=-1;next};$3>M {M=$3};END {print M}' trained_models/${task_name}_srcmt_${model_type}/val.qe_metrics)
 

--- a/utils/test-BiRNNsent.sh
+++ b/utils/test-BiRNNsent.sh
@@ -16,7 +16,7 @@ TESTVAL=$(awk -v backend=$KERAS_BACKEND -v level=$level -v task_name=$task_name 
 
 python utils/getTestData_BiRNNsent.py
 
-PYTHONHASHSEED=0 python __main__.py train -c ${conf} TASK_NAME=$task_name DATASET_NAME=$task_name MODEL_TYPE=$model_type MODEL_NAME=$model_name || true > log-${model_name}-test.txt
+python __main__.py train -s 1 -c ${conf} TASK_NAME=$task_name DATASET_NAME=$task_name MODEL_TYPE=$model_type MODEL_NAME=$model_name || true > log-${model_name}-test.txt
 
 PCC=$(awk -F, '/pearson/ {M=-1;next};$3>M {M=$3};END {print M}' trained_models/${task_name}_srcmt_${model_type}/val.qe_metrics)
 
@@ -30,7 +30,7 @@ else
   TRAIN_RESULT="passed"
   echo "QE training $TRAIN_RESULT ($level  level BiRNN with $KERAS_BACKEND on $task_name test dataset)"
   EPOCH=$(awk -F, '/pearson/ {M=-1;next};$3>M {M=$3;E=$1};END {print E}' trained_models/${task_name}_srcmt_${model_type}/val.qe_metrics)
-  PYTHONHASHSEED=0 python __main__.py predict --dataset datasets/Dataset_${task_name}_srcmt.pkl --model trained_models/${model_name}/epoch_${EPOCH}.h5 --save_path saved_predictions/prediction_${task_name}/ --evalset test
+  python __main__.py predict --dataset datasets/Dataset_${task_name}_srcmt.pkl --model trained_models/${model_name}/epoch_${EPOCH}.h5 --save_path saved_predictions/prediction_${task_name}/ --evalset test
   PCC=$(awk -F, '/pearson/ {M=-1;next};$3>M {M=$3};END {print M}' saved_predictions/prediction_${task_name}/test.qe_metrics)
   TESTVAL=$(awk -v backend=$KERAS_BACKEND -v level=${level}Predict -v task_name=$task_name -v metric=$metric -F,\
    'NR==1 {next};$1==backend && $2==level && $3==task_name && $4==metric {M=$5};END {print M}' utils/testVals.csv )

--- a/utils/test-BiRNNword.sh
+++ b/utils/test-BiRNNword.sh
@@ -16,7 +16,7 @@ TESTVAL=$(awk -v backend=$KERAS_BACKEND -v level=$level -v task_name=$task_name 
 
 python utils/getTestData_BiRNNword.py
 
-python __main__.py train -s 1 -c ${conf} TASK_NAME=$task_name DATASET_NAME=$task_name MODEL_TYPE=$model_type MODEL_NAME=$model_name || true > log-${model_name}-test.txt
+python __main__.py train -c ${conf} TASK_NAME=$task_name DATASET_NAME=$task_name MODEL_TYPE=$model_type MODEL_NAME=$model_name || true > log-${model_name}-test.txt
 
 PCC=$(awk -F, '/f1_prod/ {M=-1;next};$2>M {M=$2};END {print M}' trained_models/${task_name}_srcmt_${model_type}/val.qe_metrics)
 

--- a/utils/test-BiRNNword.sh
+++ b/utils/test-BiRNNword.sh
@@ -16,7 +16,7 @@ TESTVAL=$(awk -v backend=$KERAS_BACKEND -v level=$level -v task_name=$task_name 
 
 python utils/getTestData_BiRNNword.py
 
-PYTHONHASHSEED=0 python __main__.py train -c ${conf} TASK_NAME=$task_name DATASET_NAME=$task_name MODEL_TYPE=$model_type MODEL_NAME=$model_name || true > log-${model_name}-test.txt
+python __main__.py train -s 1 -c ${conf} TASK_NAME=$task_name DATASET_NAME=$task_name MODEL_TYPE=$model_type MODEL_NAME=$model_name || true > log-${model_name}-test.txt
 
 PCC=$(awk -F, '/f1_prod/ {M=-1;next};$2>M {M=$2};END {print M}' trained_models/${task_name}_srcmt_${model_type}/val.qe_metrics)
 
@@ -30,7 +30,7 @@ else
   TRAIN_RESULT="passed"
   echo "QE training $TRAIN_RESULT ($level  level BiRNN with $KERAS_BACKEND on $task_name test dataset)"
   EPOCH=$(awk -F, '/f1_prod/ {M=-1;next};$2>M {M=$2;E=$1};END {print E}' trained_models/${task_name}_srcmt_${model_type}/val.qe_metrics)
-  PYTHONHASHSEED=0 python __main__.py predict --dataset datasets/Dataset_${task_name}_srcmt.pkl --model trained_models/${model_name}/epoch_${EPOCH}.h5 --save_path saved_predictions/prediction_${task_name}/ --evalset test
+  python __main__.py predict --dataset datasets/Dataset_${task_name}_srcmt.pkl --model trained_models/${model_name}/epoch_${EPOCH}.h5 --save_path saved_predictions/prediction_${task_name}/ --evalset test
   PCC=$(awk -F, '/f1_prod/ {M=-1;next};$2>M {M=$2};END {print M}' saved_predictions/prediction_${task_name}/test.qe_metrics)
   TESTVAL=$(awk -v backend=$KERAS_BACKEND -v level=${level}Predict -v task_name=$task_name -v metric=$metric -F,\
    'NR==1 {next};$1==backend && $2==level && $3==task_name && $4==metric {M=$5};END {print M}' utils/testVals.csv )


### PR DESCRIPTION
This will make seed setting an option from the command line, run as follows:
```shell
dq train -s 42 -c config.yml .......
```
or
```shell
python __main__.py train -s 42 -c config.yml .......
```
omitting the -s option leaves the seed setting as random, for normal training.