### PR TITLE
Prevent model overwrite

### DIFF
--- a/configs/config-sent-BiRNN.yml
+++ b/configs/config-sent-BiRNN.yml
@@ -1,5 +1,6 @@
 # Input data params
 TASK_NAME: 'testData-sent'                         # Task name
+DATA_DIR: 'data/'                                  # Data directory
 SRC_LAN: 'src'                                     # Language of the source text
 TRG_LAN: 'mt'                                      # Language of the target text
 # SRC_LAN or TRG_LAN are expected to be the file extensions of the data files
@@ -15,8 +16,6 @@ OUT_ACTIVATION: 'sigmoid'                           #set as ‘relu’ function 
 METRICS: ['qe_metrics']                             # Metric used for evaluating the model
 EVAL_ON_SETS: ['val']                               # Possible values: 'train', 'val' and 'test' (external evaluator)
 NO_REF: False                                       # True if there is no reference data
-
-PRED_WEIGHTS: 'trained_models/testData-doc_srcmt_EncDoc/epoch_3.h5'
 
 MAX_INPUT_TEXT_LEN: 70                              # Maximum length of the input sequence
 

--- a/configs/config-sent-BiRNN.yml
+++ b/configs/config-sent-BiRNN.yml
@@ -1,6 +1,5 @@
 # Input data params
 TASK_NAME: 'testData-sent'                         # Task name
-DATA_DIR: 'data/'                                  # Data directory
 SRC_LAN: 'src'                                     # Language of the source text
 TRG_LAN: 'mt'                                      # Language of the target text
 # SRC_LAN or TRG_LAN are expected to be the file extensions of the data files

--- a/configs/default-config-BiRNN.yml
+++ b/configs/default-config-BiRNN.yml
@@ -12,6 +12,7 @@ WORD_QE_CLASSES: 5
 #OUTPUTS_IDS_DATASET_FULL: ['target_text', 'word_qe', 'sent_hter']   # Corresponding outputs of the dataset #UNUSED?
 #OUTPUTS_IDS_MODEL_FULL: ['target_text','word_qe', 'sent_hter']      # Corresponding outputs of the built model #UNUSED
 
+DATA_DIR: 'data/'                                  # Data directory
 MODEL_DIRECTORY: 'trained_models/'                # Trained models will be stored here
 DATASET_STORE_PATH: 'datasets/'                   # Dataset instance will be stored here
 

--- a/configs/default-config-BiRNN.yml
+++ b/configs/default-config-BiRNN.yml
@@ -12,6 +12,8 @@ WORD_QE_CLASSES: 5
 #OUTPUTS_IDS_DATASET_FULL: ['target_text', 'word_qe', 'sent_hter']   # Corresponding outputs of the dataset #UNUSED?
 #OUTPUTS_IDS_MODEL_FULL: ['target_text','word_qe', 'sent_hter']      # Corresponding outputs of the built model #UNUSED
 
+MODEL_DIRECTORY: 'trained_models/'                # Trained models will be stored here
+DATASET_STORE_PATH: 'datasets/'                   # Dataset instance will be stored here
 
 #EVAL_ON_SETS_KERAS: ['val']                 # Possible values: 'train', 'val' and 'test' (Keras' evaluator). Untested.
 EVAL_ON_SETS_KERAS: []
@@ -205,8 +207,6 @@ USE_PRELU: False                             # use PReLU activations as regulari
 USE_L2: False                                # L2 normalization on the features
 
 DOUBLE_STOCHASTIC_ATTENTION_REG: 0.0         # Doubly stochastic attention (Eq. 14 from arXiv:1502.03044)
-
-DATASET_STORE_PATH: 'datasets/'                   # Dataset instance will be stored here
 
 SAMPLING_SAVE_MODE: 'listoflists'                        # 'list': Store in a text file, one sentence per line.
 VERBOSE: 1                                        # Verbosity level

--- a/predict.py
+++ b/predict.py
@@ -8,7 +8,7 @@ import sys
 import pickle
 
 from data_engine.prepare_data import build_dataset, update_dataset_from_file, keep_n_captions
-from keras_wrapper.cnn_model import loadModel, updateModel
+from keras_wrapper.cnn_model import loadModel
 from keras_wrapper.dataset import loadDataset, saveDataset
 from dq_utils.callbacks import *
 from nmt_keras.model_zoo import TranslationModel

--- a/train.py
+++ b/train.py
@@ -311,7 +311,6 @@ def buildCallbacks(params, model, dataset):
         #     callbacks.append(callback_sampling)
     return callbacks
 
-
 def main(args):
     logger.info(args)
     # load the default config parameters
@@ -326,7 +325,7 @@ def main(args):
         #adding parameters that are dependent on others
         parameters['MODE'] = 'training'
         parameters['DATASET_NAME'] = parameters['TASK_NAME']
-        parameters['DATA_ROOT_PATH'] = parameters['DATA_DIR'] + '/' parameters['DATASET_NAME']
+        parameters['DATA_ROOT_PATH'] = parameters['DATA_DIR'] + '/' + parameters['DATASET_NAME']
         parameters['MAPPING'] = parameters['DATA_ROOT_PATH'] + '/mapping.%s_%s.pkl' % (parameters['SRC_LAN'], parameters['TRG_LAN'])
         parameters['BPE_CODES_PATH'] =  parameters['DATA_ROOT_PATH'] + '/training_codes.joint'
         parameters['MODEL_NAME'] = parameters['TASK_NAME'] + '_' + parameters['SRC_LAN'] + parameters['TRG_LAN'] + '_' + parameters['MODEL_TYPE']
@@ -351,7 +350,6 @@ def main(args):
     except ValueError:
         print ('Error processing arguments: (', k, ",", v, ")")
         return 2
-
 
     # check if model already exists
     if not os.path.exists(parameters['STORE_PATH']):
@@ -384,7 +382,6 @@ def main(args):
 
     if parameters['MULTI_TASK']:
 
-
         total_epochs=parameters['MAX_EPOCH']
         epoch_per_update = parameters['EPOCH_PER_UPDATE']
 
@@ -395,7 +392,6 @@ def main(args):
 
                 trainable_est = True
                 trainable_pred = True
-
 
                 if i>0 and 'PRED_WEIGHTS' in parameters:
                     del parameters['PRED_WEIGHTS']
@@ -419,8 +415,6 @@ def main(args):
                     parameters['LOSS'] = 'mse'
                     if i==0:
                         trainable_pred = False
-
-
 
                 elif output == 'word_qe':
 

--- a/train.py
+++ b/train.py
@@ -314,7 +314,7 @@ def buildCallbacks(params, model, dataset):
 
 
 def main(args):
-    print(args)
+    logger.info(args)
     # load the default config parameters
     # load the user config and overwrite any defaults
     if args.config.endswith('.yml'):
@@ -351,6 +351,34 @@ def main(args):
     except ValueError:
         print ('Error processing arguments: (', k, ",", v, ")")
         return 2
+
+
+    # check if model already exists
+    if not os.path.exists(parameters['STORE_PATH']):
+        # write out initial parameters
+        os.makedirs(parameters['STORE_PATH'])
+        dict2pkl(parameters, parameters['STORE_PATH'] + 'config_init.pkl')
+    else:
+        logger.info('Model ' + parameters['STORE_PATH'] + 'already exists. ')
+        prev_config_init = parameters['STORE_PATH'] + 'config_init.pkl'
+        logger.info('Loading trained model config_init.pkl from ' + prev_config_init)
+        parameters_prev_trained_model = pkl2dict(prev_config_init)
+        if parameters != parameters_prev_trained_model:
+            for key in parameters_prev_trained_model:
+                if not key in parameters:
+                    logger.info('Previously trained model config does not contain ' + key)
+                elif parameters[key] != parameters_prev_trained_model[key]:
+                    logger.info('Previous model has ' + key + ': ' + str(parameters[key]) + ' but this model has ' + key + ': ' + str(parameters_prev_trained_model[key]))
+            for key in parameters:
+                if not key in parameters_prev_trained_model:
+                    logger.info('New model config does not contain ' + key)
+                elif parameters[key] != parameters_prev_trained_model[key]:
+                    logger.info('Previous model has ' + key + ': ' + str(parameters[key]) + ' but this model has ' + key + ': ' + str(parameters_prev_trained_model[key]))
+            raise Exception('Model parameters not equal, can not resume training. ')
+        else:
+            logger.info('Previously trained config and new config are the same, resuming training. ')
+            #FIXME need to work on resuming
+            raise NotImplementedError('Model resuming not implemented. ')
 
     check_params(parameters)
 

--- a/train.py
+++ b/train.py
@@ -382,112 +382,110 @@ def main(args):
 
     check_params(parameters)
 
-    if parameters['MODE'] == 'training':
-
-        if parameters['MULTI_TASK']:
+    if parameters['MULTI_TASK']:
 
 
-            total_epochs=parameters['MAX_EPOCH']
-            epoch_per_update = parameters['EPOCH_PER_UPDATE']
+        total_epochs=parameters['MAX_EPOCH']
+        epoch_per_update = parameters['EPOCH_PER_UPDATE']
 
-            weights_dict = dict()
-            for i in range(total_epochs):
+        weights_dict = dict()
+        for i in range(total_epochs):
 
-                for output in parameters['OUTPUTS_IDS_DATASET_FULL']:
+            for output in parameters['OUTPUTS_IDS_DATASET_FULL']:
 
-                    trainable_est = True
-                    trainable_pred = True
+                trainable_est = True
+                trainable_pred = True
 
 
-                    if i>0 and 'PRED_WEIGHTS' in parameters:
-                        del parameters['PRED_WEIGHTS']
-                        #parameters['PRED_WEIGHTS'] = os.getcwd()+'/trained_models/'+parameters['MODEL_NAME']+'/epoch_'+str(parameters['EPOCH_PER_MODEL'])+'_weights.h5'
+                if i>0 and 'PRED_WEIGHTS' in parameters:
+                    del parameters['PRED_WEIGHTS']
+                    #parameters['PRED_WEIGHTS'] = os.getcwd()+'/trained_models/'+parameters['MODEL_NAME']+'/epoch_'+str(parameters['EPOCH_PER_MODEL'])+'_weights.h5'
 
-                    parameters['OUTPUTS_IDS_DATASET'] = [output]
-                    parameters['OUTPUTS_IDS_MODEL'] = [output]
+                parameters['OUTPUTS_IDS_DATASET'] = [output]
+                parameters['OUTPUTS_IDS_MODEL'] = [output]
 
-                    if output == 'target_text' and i>0:
+                if output == 'target_text' and i>0:
 
-                        parameters['MODEL_TYPE'] = 'Predictor'
-                        parameters['MODEL_NAME'] = 'Predictor'
-                        parameters['EPOCH_PER_MODEL'] = parameters['EPOCH_PER_PRED']
-                        parameters['LOSS'] = 'categorical_crossentropy'
+                    parameters['MODEL_TYPE'] = 'Predictor'
+                    parameters['MODEL_NAME'] = 'Predictor'
+                    parameters['EPOCH_PER_MODEL'] = parameters['EPOCH_PER_PRED']
+                    parameters['LOSS'] = 'categorical_crossentropy'
 
-                    elif output == 'sent_hter':
+                elif output == 'sent_hter':
 
-                        parameters['MODEL_TYPE'] = 'EstimatorSent'
-                        parameters['MODEL_NAME'] = 'EstimatorSent'
-                        parameters['EPOCH_PER_MODEL'] = parameters['EPOCH_PER_EST_SENT']
-                        parameters['LOSS'] = 'mse'
-                        if i==0:
-                            trainable_pred = False
+                    parameters['MODEL_TYPE'] = 'EstimatorSent'
+                    parameters['MODEL_NAME'] = 'EstimatorSent'
+                    parameters['EPOCH_PER_MODEL'] = parameters['EPOCH_PER_EST_SENT']
+                    parameters['LOSS'] = 'mse'
+                    if i==0:
+                        trainable_pred = False
 
 
 
-                    elif output == 'word_qe':
+                elif output == 'word_qe':
 
-                        parameters['MODEL_TYPE'] = 'EstimatorWord'
-                        parameters['MODEL_NAME'] = 'EstimatorWord'
-                        parameters['EPOCH_PER_MODEL'] = parameters['EPOCH_PER_EST_WORD']
-                        parameters['LOSS'] = 'categorical_crossentropy'
-                        if i==0:
-                            trainable_pred = False
+                    parameters['MODEL_TYPE'] = 'EstimatorWord'
+                    parameters['MODEL_NAME'] = 'EstimatorWord'
+                    parameters['EPOCH_PER_MODEL'] = parameters['EPOCH_PER_EST_WORD']
+                    parameters['LOSS'] = 'categorical_crossentropy'
+                    if i==0:
+                        trainable_pred = False
 
-                    else:
-                        continue
-                    parameters['STORE_PATH'] = 'trained_models/' + parameters['MODEL_NAME'] + '/'
+                else:
+                    continue
+                parameters['STORE_PATH'] = 'trained_models/' + parameters['MODEL_NAME'] + '/'
 
-                    for j in range(epoch_per_update):
+                for j in range(epoch_per_update):
 
-                        logging.info('Running training task for ' + parameters['MODEL_NAME'])
-                        parameters['MAX_EPOCH'] = parameters['EPOCH_PER_MODEL']
+                    logging.info('Running training task for ' + parameters['MODEL_NAME'])
+                    parameters['MAX_EPOCH'] = parameters['EPOCH_PER_MODEL']
 
-                        train_model(parameters, weights_dict, args.dataset, trainable_est=trainable_est, trainable_pred=trainable_pred, weights_path=parameters.get('PRED_WEIGHTS', None))
+                    train_model(parameters, weights_dict, args.dataset, trainable_est=trainable_est, trainable_pred=trainable_pred, weights_path=parameters.get('PRED_WEIGHTS', None))
 
-                        flag=True
+                    flag=True
 
-                # for j in epoch_per_update:
-                #
-                #     counter=parameters['EPOCH_PER_PRED_EST']
-                #
-                #     for i in range(parameters['EPOCH_PER_PRED_EST'] + parameters['EPOCH_PER_EST']):
-                #
-                #         # do a first pass using pretrained Predictor weights
-                #         if i==0:
-                #             logging.info('Running training task1.')
-                #             parameters['MAX_EPOCH']=parameters['EPOCH_PER_PRED_EST']
-                #
-                #             train_model(parameters, args.dataset, trainable=True, weights_path=parameters['PRED_WEIGHTS'])
-                #
-                #             # delete weights used for initialization
-                #             if 'PRED_WEIGHTS' in parameters:
-                #                 del parameters['PRED_WEIGHTS']
-                #
-                #             # parameters['REBUILD_DATASET'] = False
-                #
-                #         else:
-                #
-                #             # loop over whole stack and partial updates
-                #             if i % 2 == 0:
-                #
-                #                 logging.info('Running training Predictor+Estimator')
-                #                 parameters['MAX_EPOCH'] = counter + parameters['EPOCH_PER_PRED_EST']
-                #                 parameters['RELOAD'] = counter
-                #                 train_model(parameters, args.dataset, trainable=True)
-                #                 counter += parameters['EPOCH_PER_PRED_EST']
-                #
-                #             else:
-                #
-                #                 logging.info('Running training Estimator')
-                #                 parameters['MAX_EPOCH'] = counter + parameters['EPOCH_PER_EST']
-                #                 parameters['RELOAD'] = counter
-                #                 train_model(parameters, args.dataset, trainable=False)
-                #                 counter += parameters['EPOCH_PER_EST']
+            # for j in epoch_per_update:
+            #
+            #     counter=parameters['EPOCH_PER_PRED_EST']
+            #
+            #     for i in range(parameters['EPOCH_PER_PRED_EST'] + parameters['EPOCH_PER_EST']):
+            #
+            #         # do a first pass using pretrained Predictor weights
+            #         if i==0:
+            #             logging.info('Running training task1.')
+            #             parameters['MAX_EPOCH']=parameters['EPOCH_PER_PRED_EST']
+            #
+            #             train_model(parameters, args.dataset, trainable=True, weights_path=parameters['PRED_WEIGHTS'])
+            #
+            #             # delete weights used for initialization
+            #             if 'PRED_WEIGHTS' in parameters:
+            #                 del parameters['PRED_WEIGHTS']
+            #
+            #             # parameters['REBUILD_DATASET'] = False
+            #
+            #         else:
+            #
+            #             # loop over whole stack and partial updates
+            #             if i % 2 == 0:
+            #
+            #                 logging.info('Running training Predictor+Estimator')
+            #                 parameters['MAX_EPOCH'] = counter + parameters['EPOCH_PER_PRED_EST']
+            #                 parameters['RELOAD'] = counter
+            #                 train_model(parameters, args.dataset, trainable=True)
+            #                 counter += parameters['EPOCH_PER_PRED_EST']
+            #
+            #             else:
+            #
+            #                 logging.info('Running training Estimator')
+            #                 parameters['MAX_EPOCH'] = counter + parameters['EPOCH_PER_EST']
+            #                 parameters['RELOAD'] = counter
+            #                 train_model(parameters, args.dataset, trainable=False)
+            #                 counter += parameters['EPOCH_PER_EST']
 
-        else:
+    else:
 
-            logging.info('Running training task.')
-            train_model(parameters, args.dataset, trainable_est=True, trainable_pred=True, weights_path=parameters.get('PRED_WEIGHTS', None))
+        logging.info('Running training task.')
+        train_model(parameters, args.dataset, trainable_est=True, trainable_pred=True, weights_path=parameters.get('PRED_WEIGHTS', None))
 
 
     logger.info('Done!')

--- a/train.py
+++ b/train.py
@@ -18,7 +18,6 @@ from timeit import default_timer as timer
 import yaml
 
 from keras_wrapper.extra.read_write import pkl2dict, dict2pkl
-from keras_wrapper.extra.read_write import pkl2dict, dict2pkl
 
 from dq_utils.datatools import preprocessDoc
 
@@ -327,13 +326,14 @@ def main(args):
         #adding parameters that are dependent on others
         parameters['MODE'] = 'training'
         parameters['DATASET_NAME'] = parameters['TASK_NAME']
-        parameters['DATA_ROOT_PATH'] = 'examples/%s/' % parameters['DATASET_NAME']
+        parameters['DATA_ROOT_PATH'] = parameters['DATA_DIR'] + '/' parameters['DATASET_NAME']
         parameters['MAPPING'] = parameters['DATA_ROOT_PATH'] + '/mapping.%s_%s.pkl' % (parameters['SRC_LAN'], parameters['TRG_LAN'])
         parameters['BPE_CODES_PATH'] =  parameters['DATA_ROOT_PATH'] + '/training_codes.joint'
         parameters['MODEL_NAME'] = parameters['TASK_NAME'] + '_' + parameters['SRC_LAN'] + parameters['TRG_LAN'] + '_' + parameters['MODEL_TYPE']
-        parameters['STORE_PATH'] = 'trained_models/' + parameters['MODEL_NAME'] + '/'
+        parameters['STORE_PATH'] = parameters['MODEL_DIRECTORY'] + parameters['MODEL_NAME'] + '/'
     elif args.config.endswith('.pkl'):
         parameters = update_parameters(parameters, pkl2dict(args.config))
+
     try:
         for arg in args.changes:
             try:

--- a/utils/getTestData_BiRNNdoc.py
+++ b/utils/getTestData_BiRNNdoc.py
@@ -72,7 +72,7 @@ for file in os.listdir(cachePath):
         # os.remove(file)
         # print('Deleting: ' + file)
 
-dataDir = 'examples/' + task
+dataDir = 'data/' + task
 os.makedirs(dataDir, exist_ok=True)
 
 trainSize = 100

--- a/utils/getTestData_BiRNNsent.py
+++ b/utils/getTestData_BiRNNsent.py
@@ -41,7 +41,7 @@ for file in os.listdir(cachePath):
         tar.close()
 
 # make the test data
-dataDir = 'examples/'+task
+dataDir = 'data/'+task
 os.makedirs(dataDir, exist_ok=True)
 
 totalLines = 500 # total number of lines to take from example data

--- a/utils/getTestData_BiRNNword.py
+++ b/utils/getTestData_BiRNNword.py
@@ -41,7 +41,7 @@ for file in os.listdir(cachePath):
         tar.close()
 
 ## make the test data
-dataDir = 'examples/'+task
+dataDir = 'data/'+task
 os.makedirs(dataDir, exist_ok=True)
 
 totalLines = 500 # total number of lines to take from example data


### PR DESCRIPTION
As per @fredblain's request (documented in https://github.com/RSE-Sheffield/deepquest/issues/21) I've implemented some code that prevents models from being overwritten during training.

The way this runs now is:
1. If there is no model with the same name, training starts (from epoch 1) as normal.
2. If there is a model with the same name already, it checks the parameters currently specified.
3. If those parameters are exactly the same as for the previously trained model, it prompts the user to set the RELOAD_EPOCH and RELOAD parameters.
4. If the only parameters that differ are RELOAD and RELOAD_EPOCH, it resumes training from the specified epoch.
5. If any other parameters differ, it refuses to train, informs the user, logs a message and quits. This is assuming that resuming training on a model with different parameters would be an odd thing to do.
6. If you want to avoid this, then you can just rename the directory of the already trained model or move it.

As for all other parameters'; RELOAD and RELOAD_EPOCH can be set either in the config.yml or on the command line as in:
```shell
dq train -c config.yml RELOAD=8 RELOAD_EPOCH=True
```
