### PR TITLE
Move command line arg handling to __main__.py

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,0 +1,1 @@
+from .train import main as train

--- a/__init__.py
+++ b/__init__.py
@@ -1,1 +1,3 @@
 from .train import main as train
+from .predict import main as predict
+from .score import main as score

--- a/__main__.py
+++ b/__main__.py
@@ -1,9 +1,11 @@
 import argparse
 
+
 def train(args):
     import yaml
     if args.config.endswith('.yml'):
-        with open('configs/default-config-BiRNN.yml') as file: #FIXME make this a user option (maybe depend on model type and level?)
+        # FIXME make this a user option (maybe depend on model type and level?)
+        with open('configs/default-config-BiRNN.yml') as file:
             parameters = yaml.load(file, Loader=yaml.FullLoader)
         with open(args.config) as file:
             user_parameters = yaml.load(file, Loader=yaml.FullLoader)
@@ -19,15 +21,18 @@ def train(args):
         import random
         random.seed(parameters['SEED'])
     import train
-    train.main(parameters,args.dataset)
+    train.main(parameters, args.dataset)
+
 
 def predict(args):
     import predict
-    predict.main(args.model,args.dataset,args.save_path,args.evalset,changes2dict(args))
+    predict.main(args.model, args.dataset, args.save_path, args.evalset, changes2dict(args))
+
 
 def score(args):
     import score
     score.main(args.files)
+
 
 def changes2dict(args):
     import ast
@@ -54,8 +59,10 @@ def changes2dict(args):
     else:
         return {}
 
+
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser("A framework for neural-based quality estimation for machine translation. ")
+    parser = argparse.ArgumentParser(
+        "A framework for neural-based quality estimation for machine translation. ")
     subparsers = parser.add_subparsers(help='train '
                                             'predict '
                                             'score ')
@@ -63,31 +70,35 @@ if __name__ == "__main__":
     # parser for training
     train_parser = subparsers.add_parser('train', help='Train QE models')
     train_parser.set_defaults(func=train)
-    train_parser.add_argument("-c", "--config",   required=False, help="Config YAML or pkl for loading the model configuration. ")
-    train_parser.add_argument("-ds", "--dataset", required=False, help="Optional dataset instance to be trained on. ")
+    train_parser.add_argument("-c", "--config",   required=False,
+                              help="Config YAML or pkl for loading the model configuration. ")
+    train_parser.add_argument("-ds", "--dataset", required=False,
+                              help="Optional dataset instance to be trained on. ")
     train_parser.add_argument("changes", nargs="*", help="Changes to config. "
-                                                   "Following the syntax Key=Value",
-                                                    default="")
+                              "Following the syntax Key=Value",
+                              default="")
 
     # parser for prediction
     predict_parser = subparsers.add_parser('predict', help='Sample using trained QE models')
     predict_parser.set_defaults(func=predict)
     predict_parser.add_argument("--model", required=True,
-        help="model file (.h5) to use")
+                                help="model file (.h5) to use")
     predict_parser.add_argument("--dataset", required=True,
-        help="dataset file (.pkl) to use")
+                                help="dataset file (.pkl) to use")
     predict_parser.add_argument("--save_path", required=False, help="Directory path to save predictions to. "
-                                                                "If not specified, defaults to STORE_PATH")
+                                "If not specified, defaults to STORE_PATH")
     predict_parser.add_argument("--evalset", required=False, help="Set to evaluate on. "
-                                                                "Defaults to 'test' if not specified. ")
+                                "Defaults to 'test' if not specified. ")
     predict_parser.add_argument("changes", nargs="*", help="Changes to config. "
-                                                   "Following the syntax Key=Value",
-                                                   default="")
+                                "Following the syntax Key=Value",
+                                default="")
 
     # parser for scoring
-    score_parser = subparsers.add_parser('score', help='Evaluate a set of predictions with regard to a reference set. ')
+    score_parser = subparsers.add_parser(
+        'score', help='Evaluate a set of predictions with regard to a reference set. ')
     score_parser.set_defaults(func=score)
-    score_parser.add_argument("files", nargs=2, help="Two text files containing predictions and references. ")
+    score_parser.add_argument(
+        "files", nargs=2, help="Two text files containing predictions and references. ")
 
     args = parser.parse_args()
     args.func(args)

--- a/__main__.py
+++ b/__main__.py
@@ -3,7 +3,8 @@ import argparse
 def train(args):
     set_seed(args)
     import train
-    train.main(args)
+    parameters = args2dict(args)
+    train.main(parameters)
 
 def predict(args):
     import predict
@@ -13,7 +14,7 @@ def score(args):
     import score
     score.main(args)
 
-def set_seed(args):
+def args2dict(args):
     import ast
     import yaml
     if args.config.endswith('.yml'):
@@ -42,14 +43,17 @@ def set_seed(args):
     except ValueError:
         print ('Error processing arguments: (', k, ",", v, ")")
         return 2
+    return parameters
+
+def set_seed(args):
+    parameters = args2dict(args)
     if parameters['SEED']:
         print('Setting deepQuest seed to', parameters['SEED'])
         import numpy.random
         numpy.random.seed(parameters['SEED'])
         import random
         random.seed(parameters['SEED'])
-    else:
-        return
+    return parameters
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser("A framework for neural-based quality estimation for machine translation. ")

--- a/predict.py
+++ b/predict.py
@@ -13,8 +13,10 @@ from dq_utils.callbacks import *
 import nmt_keras.models as modFactory
 import nmt_keras.dq_evaluation as dq_evaluation
 
-logging.basicConfig(level=logging.DEBUG, format='[%(asctime)s] %(message)s', datefmt='%d/%m/%Y %H:%M:%S')
+logging.basicConfig(level=logging.DEBUG,
+                    format='[%(asctime)s] %(message)s', datefmt='%d/%m/%Y %H:%M:%S')
 logger = logging.getLogger(__name__)
+
 
 def apply_NMT_model(params, dataset, model, save_path):
     """
@@ -65,7 +67,7 @@ def apply_NMT_model(params, dataset, model, save_path):
         extra_vars[s] = dict()
         # True when we should score against a reference
 
-        #add the test split reference to the dataset
+        # add the test split reference to the dataset
         path_list = os.path.join(params['DATA_ROOT_PATH'], s + '.' + params['PRED_SCORE'])
         if dataset.ids_outputs[0] == 'word_qe':
             out_type = 'text'
@@ -73,18 +75,18 @@ def apply_NMT_model(params, dataset, model, save_path):
             out_type = 'real'
 
         if not params.get('NO_REF', False):
-            if not dataset.loaded_raw_test[1] and s=='test':
+            if not dataset.loaded_raw_test[1] and s == 'test':
                 dataset.setRawOutput(path_list, set_name=s, type='file-name', id='raw_'+id_out, overwrite_split=False,
-                            add_additional=False)
-            if not dataset.loaded_test[1] and s=='test':
+                                     add_additional=False)
+            if not dataset.loaded_test[1] and s == 'test':
                 dataset.setOutput(path_list, set_name=s, type=out_type, id=id_out, repeat_set=1, overwrite_split=False,
-                        add_additional=False, sample_weights=False, label_smoothing=0.,
-                        tokenization='tokenize_none', max_text_len=0, offset=0, fill='end', min_occ=0,  # 'text'
-                        pad_on_batch=True, words_so_far=False, build_vocabulary=False, max_words=0,  # 'text'
-                        bpe_codes=None, separator='@@', use_unk_class=False,  # 'text'
-                        associated_id_in=None, num_poolings=None,  # '3DLabel' or '3DSemanticLabel'
-                        sparse=False,  # 'binary'
-                        )
+                                  add_additional=False, sample_weights=False, label_smoothing=0.,
+                                  tokenization='tokenize_none', max_text_len=0, offset=0, fill='end', min_occ=0,  # 'text'
+                                  pad_on_batch=True, words_so_far=False, build_vocabulary=False, max_words=0,  # 'text'
+                                  bpe_codes=None, separator='@@', use_unk_class=False,  # 'text'
+                                  associated_id_in=None, num_poolings=None,  # '3DLabel' or '3DSemanticLabel'
+                                  sparse=False,  # 'binary'
+                                  )
             keep_n_captions(dataset, repeat=1, n=1, set_names=params['EVAL_ON_SETS'])
 
         input_text_id = params['INPUTS_IDS_DATASET'][0]
@@ -92,8 +94,8 @@ def apply_NMT_model(params, dataset, model, save_path):
         vocab_y = dataset.vocabulary[params['INPUTS_IDS_DATASET'][1]]['idx2words']
 
         callbacks = buildCallbacks(params, nmt_model, dataset)
-        metrics = callbacks.evaluate(params['RELOAD'], counter_name='epoch' if params['EVAL_EACH_EPOCHS'] else 'update')
-
+        metrics = callbacks.evaluate(
+            params['RELOAD'], counter_name='epoch' if params['EVAL_EACH_EPOCHS'] else 'update')
 
 
 def buildCallbacks(params, model, dataset):
@@ -140,9 +142,11 @@ def buildCallbacks(params, model, dataset):
             extra_vars['coverage_norm_factor'] = params.get('COVERAGE_NORM_FACTOR', 0.0)
             extra_vars['pos_unk'] = params['POS_UNK']
             extra_vars['output_max_length_depending_on_x'] = params.get('MAXLEN_GIVEN_X', True)
-            extra_vars['output_max_length_depending_on_x_factor'] = params.get('MAXLEN_GIVEN_X_FACTOR', 3)
+            extra_vars['output_max_length_depending_on_x_factor'] = params.get(
+                'MAXLEN_GIVEN_X_FACTOR', 3)
             extra_vars['output_min_length_depending_on_x'] = params.get('MINLEN_GIVEN_X', True)
-            extra_vars['output_min_length_depending_on_x_factor'] = params.get('MINLEN_GIVEN_X_FACTOR', 2)
+            extra_vars['output_min_length_depending_on_x_factor'] = params.get(
+                'MINLEN_GIVEN_X_FACTOR', 2)
 
             if params['POS_UNK']:
                 extra_vars['heuristic'] = params['HEURISTIC']
@@ -155,35 +159,36 @@ def buildCallbacks(params, model, dataset):
                 if not params.get('NO_REF', False):
                     extra_vars[s]['references'] = dataset.extra_variables[s][params['OUTPUTS_IDS_DATASET'][0]]
             callback_metric = EvalPerformance(model,
-                                            dataset,
-                                            gt_id=[params['OUTPUTS_IDS_DATASET'][0]],
-                                            metric_name=params['METRICS'],
-                                            set_name=params['EVAL_ON_SETS'],
-                                            batch_size=params['BATCH_SIZE'],
-                                            each_n_epochs=params['EVAL_EACH'],
-                                            extra_vars=extra_vars,
-                                            reload_epoch=params['RELOAD'],
-                                            is_text=True,
-                                            input_text_id=input_text_id,
-                                            index2word_y=vocab_y,
-                                            # index2word_y=dataset.vocabulary[params['OUTPUTS_IDS_DATASET'][0]]['idx2words'],
-                                            index2word_x=vocab_x,
-                                            sampling_type=params['SAMPLING'],
-                                            beam_search=params['BEAM_SEARCH'],
-                                            save_path=model.model_path,
-                                            start_eval_on_epoch=params[
-                                                'START_EVAL_ON_EPOCH'],
-                                            write_samples=True,
-                                            write_type=params['SAMPLING_SAVE_MODE'],
-                                            eval_on_epochs=params['EVAL_EACH_EPOCHS'],
-                                            save_each_evaluation=params[
-                                                'SAVE_EACH_EVALUATION'],
-                                            verbose=params['VERBOSE'],
-                                            no_ref=params['NO_REF'])
+                                              dataset,
+                                              gt_id=[params['OUTPUTS_IDS_DATASET'][0]],
+                                              metric_name=params['METRICS'],
+                                              set_name=params['EVAL_ON_SETS'],
+                                              batch_size=params['BATCH_SIZE'],
+                                              each_n_epochs=params['EVAL_EACH'],
+                                              extra_vars=extra_vars,
+                                              reload_epoch=params['RELOAD'],
+                                              is_text=True,
+                                              input_text_id=input_text_id,
+                                              index2word_y=vocab_y,
+                                              # index2word_y=dataset.vocabulary[params['OUTPUTS_IDS_DATASET'][0]]['idx2words'],
+                                              index2word_x=vocab_x,
+                                              sampling_type=params['SAMPLING'],
+                                              beam_search=params['BEAM_SEARCH'],
+                                              save_path=model.model_path,
+                                              start_eval_on_epoch=params[
+                                                  'START_EVAL_ON_EPOCH'],
+                                              write_samples=True,
+                                              write_type=params['SAMPLING_SAVE_MODE'],
+                                              eval_on_epochs=params['EVAL_EACH_EPOCHS'],
+                                              save_each_evaluation=params[
+                                                  'SAVE_EACH_EVALUATION'],
+                                              verbose=params['VERBOSE'],
+                                              no_ref=params['NO_REF'])
 
             callbacks = callback_metric
 
     return callbacks
+
 
 def check_params(params):
     """
@@ -206,7 +211,7 @@ def check_params(params):
                       'You should preprocess the word embeddings with the "utils/preprocess_*_word_vectors.py script.')
 
 
-def main(model,dataset,save_path=None,evalset=None,changes={}):
+def main(model, dataset, save_path=None, evalset=None, changes={}):
     """
     Predicts QE scores on a dataset using a pre-trained model.
     :param model: Model file (.h5) to use.
@@ -215,7 +220,7 @@ def main(model,dataset,save_path=None,evalset=None,changes={}):
     :param evalset: Optional set to evaluate on. Default = 'test'
     :param changes: Optional dictionary of parameters to overwrite config.
     """
-    parameters = pickle.load(open(os.path.join(os.path.split(model)[0],'config.pkl'), 'rb'))
+    parameters = pickle.load(open(os.path.join(os.path.split(model)[0], 'config.pkl'), 'rb'))
 
     parameters.update(changes)
 
@@ -242,7 +247,7 @@ def main(model,dataset,save_path=None,evalset=None,changes={}):
 
     # from nmt_keras import model_zoo
     from keras.utils import CustomObjectScope
-    import nmt_keras.models.utils as layers #includes all layers and everything defined in nmt_keras.utils
+    import nmt_keras.models.utils as layers  # includes all layers and everything defined in nmt_keras.utils
     with CustomObjectScope(vars(layers)):
         apply_NMT_model(parameters, dataset, model, save_path)
 

--- a/score.py
+++ b/score.py
@@ -17,11 +17,15 @@ def read_file_to_list(file_in,logger):
             data_list.append(float(line))
     return data_list
 
-def main(args):
-    assert len(args.files) == 2, "Number of files specified must equal 2. "
+def main(files):
+    """
+    Evaluate a set of predictions with regard to a reference set.
+    :param files: List of paths to two text files containing predictions and references. 
+    """
+    assert len(files) == 2, "Number of files specified must equal 2. "
 
     data = []
-    for i,path in enumerate(args.files,1):
+    for i,path in enumerate(files,1):
         a = read_file_to_list(path,logger)
         data.append(a)
 

--- a/score.py
+++ b/score.py
@@ -5,35 +5,36 @@ import scipy.stats
 import sklearn.metrics
 from math import sqrt
 
-logging.basicConfig(level=logging.INFO, format='[%(asctime)s] %(message)s', datefmt='%d/%m/%Y %H:%M:%S')
+logging.basicConfig(level=logging.INFO,
+                    format='[%(asctime)s] %(message)s', datefmt='%d/%m/%Y %H:%M:%S')
 logger = logging.getLogger(__name__)
 
 
-def read_file_to_list(file_in,logger):
+def read_file_to_list(file_in, logger):
     logger.info('Reading %s ', file_in)
     data_list = []
-    with open(file_in) as file:
-        for line in file.readlines():
-            data_list.append(float(line))
+    with open(file_in) as inp:
+        data_list = list(map(float, inp))
     return data_list
+
 
 def main(files):
     """
     Evaluate a set of predictions with regard to a reference set.
-    :param files: List of paths to two text files containing predictions and references. 
+    :param files: List of paths to two text files containing predictions and references.
     """
     assert len(files) == 2, "Number of files specified must equal 2. "
 
     data = []
-    for i,path in enumerate(files,1):
-        a = read_file_to_list(path,logger)
+    for path in files:
+        a = read_file_to_list(path, logger)
         data.append(a)
 
     assert len(data[0]) == len(data[1]), "Files must be of equal length. "
 
-    pcc, _ = scipy.stats.pearsonr(data[0],data[1])
-    mae = sklearn.metrics.mean_absolute_error(data[0],data[1])
-    rmse = sqrt(sklearn.metrics.mean_squared_error(data[0],data[1]))
+    pcc, _ = scipy.stats.pearsonr(data[0], data[1])
+    mae = sklearn.metrics.mean_absolute_error(data[0], data[1])
+    rmse = sqrt(sklearn.metrics.mean_squared_error(data[0], data[1]))
 
     print('Mean absolute error: %.3f' % mae)
     print('Pearsons correlation: %.3f' % pcc)

--- a/train.py
+++ b/train.py
@@ -288,66 +288,10 @@ def buildCallbacks(params, model, dataset):
 
             callbacks.append(callback_metric)
 
-        # if params['SAMPLE_ON_SETS']:
-        #     callback_sampling = SampleEachNUpdates(model,
-        #                                            dataset,
-        #                                            gt_id=params['OUTPUTS_IDS_DATASET'][0],
-        #                                            set_name=params['SAMPLE_ON_SETS'],
-        #                                            n_samples=params['N_SAMPLES'],
-        #                                            each_n_updates=params['SAMPLE_EACH_UPDATES'],
-        #                                            extra_vars=extra_vars,
-        #                                            reload_epoch=params['RELOAD'],
-        #                                            batch_size=params['BATCH_SIZE'],
-        #                                            is_text=True,
-        #                                            index2word_x=vocab_x,
-        #                                            index2word_y=vocab_y,
-        #                                            print_sources=True,
-        #                                            in_pred_idx=params['INPUTS_IDS_DATASET'][0],
-        #                                            sampling_type=params['SAMPLING'],  # text info
-        #                                            beam_search=params['BEAM_SEARCH'],
-        #                                            start_sampling_on_epoch=params['START_SAMPLING_ON_EPOCH'],
-        #                                            verbose=params['VERBOSE'])
-        #     callbacks.append(callback_sampling)
     return callbacks
 
-def main(args):
-    logger.info(args)
-    # load the default config parameters
-    # load the user config and overwrite any defaults
-    if args.config.endswith('.yml'):
-        with open('configs/default-config-BiRNN.yml') as file: #FIXME make this a user option (maybe depend on model type and level?)
-            parameters = yaml.load(file, Loader=yaml.FullLoader)
-        with open(args.config) as file:
-            user_parameters = yaml.load(file, Loader=yaml.FullLoader)
-        parameters.update(user_parameters)
-        del user_parameters
-        #adding parameters that are dependent on others
-        parameters['DATASET_NAME'] = parameters['TASK_NAME']
-        parameters['DATA_ROOT_PATH'] = os.path.join(parameters['DATA_DIR'],parameters['DATASET_NAME'])
-        parameters['MAPPING'] = os.path.join(parameters['DATA_ROOT_PATH'], 'mapping.%s_%s.pkl' % (parameters['SRC_LAN'], parameters['TRG_LAN']))
-        parameters['BPE_CODES_PATH'] =  os.path.join(parameters['DATA_ROOT_PATH'], '/training_codes.joint')
-        parameters['MODEL_NAME'] = parameters['TASK_NAME'] + '_' + parameters['SRC_LAN'] + parameters['TRG_LAN'] + '_' + parameters['MODEL_TYPE']
-        parameters['STORE_PATH'] = os.path.join(parameters['MODEL_DIRECTORY'], parameters['MODEL_NAME'])
-    elif args.config.endswith('.pkl'):
-        parameters = update_parameters(parameters, pkl2dict(args.config))
-
-    try:
-        for arg in args.changes:
-            try:
-                k, v = arg.split('=')
-            except ValueError:
-                print ('Overwritten arguments must have the form key=Value. \n Currently are: %s' % str(args.changes))
-                return 2
-            if '_' in v:
-                parameters[k] = v
-            else:
-                try:
-                    parameters[k] = ast.literal_eval(v)
-                except ValueError:
-                    parameters[k] = v
-    except ValueError:
-        print ('Error processing arguments: (', k, ",", v, ")")
-        return 2
+def main(parameters):
+    logger.info(parameters)
 
     # check if model already exists
     if not os.path.exists(parameters['STORE_PATH']):

--- a/train.py
+++ b/train.py
@@ -17,9 +17,11 @@ from nmt_keras.callbacks import PrintPerformanceMetricOnEpochEndOrEachNUpdates
 import nmt_keras.models as modFactory
 from dq_utils.datatools import preprocessDoc
 
-logging.basicConfig(level=logging.INFO, format='[%(asctime)s] %(message)s', datefmt='%d/%m/%Y %H:%M:%S')
+logging.basicConfig(level=logging.INFO,
+                    format='[%(asctime)s] %(message)s', datefmt='%d/%m/%Y %H:%M:%S')
 
 logger = logging.getLogger(__name__)
+
 
 def train_model(params, weights_dict, load_dataset=None, trainable_pred=True, trainable_est=True, weights_path=None):
     """
@@ -40,7 +42,8 @@ def train_model(params, weights_dict, load_dataset=None, trainable_pred=True, tr
                 pred_vocab = params.get('PRED_VOCAB', None)
                 if pred_vocab is not None:
                     dataset_voc = loadDataset(params['PRED_VOCAB'])
-                    dataset = build_dataset(params, dataset_voc.vocabulary, dataset_voc.vocabulary_len)
+                    dataset = build_dataset(params, dataset_voc.vocabulary,
+                                            dataset_voc.vocabulary_len)
                 else:
                     dataset = build_dataset(params)
             else:
@@ -50,15 +53,17 @@ def train_model(params, weights_dict, load_dataset=None, trainable_pred=True, tr
 
                 for split, filename in params['TEXT_FILES'].iteritems():
                     dataset = update_dataset_from_file(dataset,
-                                                       params['DATA_ROOT_PATH'] + '/' + filename + params['SRC_LAN'],
+                                                       params['DATA_ROOT_PATH'] + '/' +
+                                                       filename + params['SRC_LAN'],
                                                        params,
                                                        splits=list([split]),
                                                        output_text_filename=params['DATA_ROOT_PATH'] + '/' + filename +
-                                                                            params['TRG_LAN'],
+                                                       params['TRG_LAN'],
                                                        remove_outputs=False,
                                                        compute_state_below=True,
                                                        recompute_references=True)
-                    dataset.name = params['DATASET_NAME'] + '_' + params['SRC_LAN'] + params['TRG_LAN']
+                    dataset.name = params['DATASET_NAME'] + '_' + \
+                        params['SRC_LAN'] + params['TRG_LAN']
                 saveDataset(dataset, params['DATASET_STORE_PATH'])
 
         else:
@@ -78,7 +83,8 @@ def train_model(params, weights_dict, load_dataset=None, trainable_pred=True, tr
                 if 'doc_qe' in params['OUTPUTS_IDS_MODEL']:
                     params = preprocessDoc(params)
                 elif 'EstimatorDoc' in params['MODEL_TYPE']:
-                    raise Exception('Translation_Model model_type "' + params['MODEL_TYPE'] + '" is not implemented.')
+                    raise Exception('Translation_Model model_type "' +
+                                    params['MODEL_TYPE'] + '" is not implemented.')
                 dataset = build_dataset(params)
                 if params['NO_REF']:
                     keep_n_captions(dataset, repeat=1, n=1, set_names=params['EVAL_ON_SETS'])
@@ -93,7 +99,7 @@ def train_model(params, weights_dict, load_dataset=None, trainable_pred=True, tr
     try:
         # mf = QEModelFactory()
         # qe_model = QEModelFactory(params['MODEL_TYPE'], 'sentence'))
-        #FIXME: change 'nmt_keras' for 'quest'
+        # FIXME: change 'nmt_keras' for 'quest'
         # model_obj = getattr(importlib.import_module("nmt_keras.models.{}".format(params['MODEL_TYPE'].lower())))
 
         # qe_model = model_obj(params,
@@ -131,9 +137,10 @@ def train_model(params, weights_dict, load_dataset=None, trainable_pred=True, tr
             # otherwise we just reload the weights
             # from the files containing the model
             from keras.utils import CustomObjectScope
-            import nmt_keras.models.utils as layers #includes all layers and everything defined in nmt_keras.utils
+            import nmt_keras.models.utils as layers  # includes all layers and everything defined in nmt_keras.utils
             with CustomObjectScope(vars(layers)):
-                qe_model = updateModel(qe_model, params['STORE_PATH'], params['RELOAD'], reload_epoch=params['RELOAD_EPOCH'])
+                qe_model = updateModel(
+                    qe_model, params['STORE_PATH'], params['RELOAD'], reload_epoch=params['RELOAD_EPOCH'])
             qe_model.setParams(params)
             qe_model.setOptimizer()
             params['EPOCH_OFFSET'] = params['RELOAD'] if params['RELOAD_EPOCH'] else \
@@ -188,11 +195,12 @@ def train_model(params, weights_dict, load_dataset=None, trainable_pred=True, tr
     qe_model.trainNet(dataset, training_params)
     if weights_dict is not None:
         for layer in qe_model.model.layers:
-            weights_dict[layer.name]= layer.get_weights()
+            weights_dict[layer.name] = layer.get_weights()
 
     total_end_time = timer()
     time_difference = total_end_time - total_start_time
     logging.info('In total is {0:.2f}s = {1:.2f}m'.format(time_difference, time_difference / 60.0))
+
 
 def buildCallbacks(params, model, dataset):
     """
@@ -238,9 +246,11 @@ def buildCallbacks(params, model, dataset):
             extra_vars['coverage_norm_factor'] = params.get('COVERAGE_NORM_FACTOR', 0.0)
             extra_vars['pos_unk'] = params['POS_UNK']
             extra_vars['output_max_length_depending_on_x'] = params.get('MAXLEN_GIVEN_X', True)
-            extra_vars['output_max_length_depending_on_x_factor'] = params.get('MAXLEN_GIVEN_X_FACTOR', 3)
+            extra_vars['output_max_length_depending_on_x_factor'] = params.get(
+                'MAXLEN_GIVEN_X_FACTOR', 3)
             extra_vars['output_min_length_depending_on_x'] = params.get('MINLEN_GIVEN_X', True)
-            extra_vars['output_min_length_depending_on_x_factor'] = params.get('MINLEN_GIVEN_X_FACTOR', 2)
+            extra_vars['output_min_length_depending_on_x_factor'] = params.get(
+                'MINLEN_GIVEN_X_FACTOR', 2)
 
             if params['POS_UNK']:
                 extra_vars['heuristic'] = params['HEURISTIC']
@@ -253,7 +263,8 @@ def buildCallbacks(params, model, dataset):
                 extra_vars[s]['references'] = dataset.extra_variables[s][params['OUTPUTS_IDS_DATASET'][0]]
             callback_metric = PrintPerformanceMetricOnEpochEndOrEachNUpdates(model,
                                                                              dataset,
-                                                                             gt_id=[params['OUTPUTS_IDS_DATASET'][0]],
+                                                                             gt_id=[
+                                                                                 params['OUTPUTS_IDS_DATASET'][0]],
                                                                              metric_name=params['METRICS'],
                                                                              set_name=params['EVAL_ON_SETS'],
                                                                              batch_size=params['BATCH_SIZE'],
@@ -282,16 +293,18 @@ def buildCallbacks(params, model, dataset):
 
     return callbacks
 
-def main(config=None,dataset=None,changes={}):
+
+def main(config=None, dataset=None, changes={}):
     """
     Handles QE model training.
     :param config: Either a path to a YAML or pkl config file or a dictionary of parameters.
     :param dataset: Optional path to a previously built pkl dataset.
     :param changes: Optional dictionary of parameters to overwrite config.
     """
-    if isinstance(config,str):
+    if isinstance(config, str):
         if arg.endswith('.yml'):
-            with open('configs/default-config-BiRNN.yml') as file: #FIXME make this a user option (maybe depend on model type and level?)
+            # FIXME make this a user option (maybe depend on model type and level?)
+            with open('configs/default-config-BiRNN.yml') as file:
                 parameters = yaml.load(file, Loader=yaml.FullLoader)
             with open(arg) as file:
                 user_parameters = yaml.load(file, Loader=yaml.FullLoader)
@@ -299,17 +312,21 @@ def main(config=None,dataset=None,changes={}):
             del user_parameters
         elif arg.endswith('.pkl'):
             parameters = update_parameters(parameters, pkl2dict(arg))
-    elif isinstance(config,dict):
+    elif isinstance(config, dict):
         parameters = config
     else:
-        raise Exception('Expected path string to a config yml or pkl or a parameters dictionary, but received: %s . ',type(arg))
+        raise Exception(
+            'Expected path string to a config yml or pkl or a parameters dictionary, but received: %s . ', type(arg))
 
     parameters.update(changes)
     parameters['DATASET_NAME'] = parameters['TASK_NAME']
-    parameters['DATA_ROOT_PATH'] = os.path.join(parameters['DATA_DIR'],parameters['DATASET_NAME'])
-    parameters['MAPPING'] = os.path.join(parameters['DATA_ROOT_PATH'], 'mapping.%s_%s.pkl' % (parameters['SRC_LAN'], parameters['TRG_LAN']))
-    parameters['BPE_CODES_PATH'] =  os.path.join(parameters['DATA_ROOT_PATH'], '/training_codes.joint')
-    parameters['MODEL_NAME'] = parameters['TASK_NAME'] + '_' + parameters['SRC_LAN'] + parameters['TRG_LAN'] + '_' + parameters['MODEL_TYPE']
+    parameters['DATA_ROOT_PATH'] = os.path.join(parameters['DATA_DIR'], parameters['DATASET_NAME'])
+    parameters['MAPPING'] = os.path.join(parameters['DATA_ROOT_PATH'], 'mapping.%s_%s.pkl' % (
+        parameters['SRC_LAN'], parameters['TRG_LAN']))
+    parameters['BPE_CODES_PATH'] = os.path.join(
+        parameters['DATA_ROOT_PATH'], '/training_codes.joint')
+    parameters['MODEL_NAME'] = parameters['TASK_NAME'] + '_' + \
+        parameters['SRC_LAN'] + parameters['TRG_LAN'] + '_' + parameters['MODEL_TYPE']
     parameters['STORE_PATH'] = os.path.join(parameters['MODEL_DIRECTORY'], parameters['MODEL_NAME'])
 
     print(parameters)
@@ -328,7 +345,8 @@ def main(config=None,dataset=None,changes={}):
         logger.info('Loading trained model config_init.pkl from ' + prev_config_init)
         parameters_prev = pkl2dict(prev_config_init)
         if parameters['RELOAD_EPOCH'] != True or parameters['RELOAD'] == 0:
-            logger.info('Specify RELOAD_EPOCH=True and RELOAD>0 in your config to resume training an existing model. ')
+            logger.info(
+                'Specify RELOAD_EPOCH=True and RELOAD>0 in your config to resume training an existing model. ')
             return
         elif parameters != parameters_prev:
             reload_keys = ['RELOAD', 'RELOAD_EPOCH']
@@ -338,7 +356,8 @@ def main(config=None,dataset=None,changes={}):
                     logger.info('Previously trained model config does not contain ' + key)
                     stop_flag = True
                 elif parameters[key] != parameters_prev[key] and key not in reload_keys:
-                    logger.info('Previous model has ' + key + ': ' + str(parameters[key]) + ' but this model has ' + key + ': ' + str(parameters_prev[key]))
+                    logger.info('Previous model has ' + key + ': ' +
+                                str(parameters[key]) + ' but this model has ' + key + ': ' + str(parameters_prev[key]))
                     stop_flag = True
             for key in parameters:
                 if key not in (parameters_prev or reload_keys):
@@ -349,14 +368,15 @@ def main(config=None,dataset=None,changes={}):
             else:
                 logger.info('Resuming training from epoch ' + str(parameters['RELOAD']))
         else:
-            logger.info('Previously trained config and new config are the same, specify which epoch to resume training from. ')
+            logger.info(
+                'Previously trained config and new config are the same, specify which epoch to resume training from. ')
             return
 
     check_params(parameters)
 
     if parameters['MULTI_TASK']:
 
-        total_epochs=parameters['MAX_EPOCH']
+        total_epochs = parameters['MAX_EPOCH']
         epoch_per_update = parameters['EPOCH_PER_UPDATE']
 
         weights_dict = dict()
@@ -367,14 +387,14 @@ def main(config=None,dataset=None,changes={}):
                 trainable_est = True
                 trainable_pred = True
 
-                if i>0 and 'PRED_WEIGHTS' in parameters:
+                if i > 0 and 'PRED_WEIGHTS' in parameters:
                     del parameters['PRED_WEIGHTS']
                     #parameters['PRED_WEIGHTS'] = os.getcwd()+'/trained_models/'+parameters['MODEL_NAME']+'/epoch_'+str(parameters['EPOCH_PER_MODEL'])+'_weights.h5'
 
                 parameters['OUTPUTS_IDS_DATASET'] = [output]
                 parameters['OUTPUTS_IDS_MODEL'] = [output]
 
-                if output == 'target_text' and i>0:
+                if output == 'target_text' and i > 0:
 
                     parameters['MODEL_TYPE'] = 'Predictor'
                     parameters['MODEL_NAME'] = 'Predictor'
@@ -387,7 +407,7 @@ def main(config=None,dataset=None,changes={}):
                     parameters['MODEL_NAME'] = 'EstimatorSent'
                     parameters['EPOCH_PER_MODEL'] = parameters['EPOCH_PER_EST_SENT']
                     parameters['LOSS'] = 'mse'
-                    if i==0:
+                    if i == 0:
                         trainable_pred = False
 
                 elif output == 'word_qe':
@@ -396,7 +416,7 @@ def main(config=None,dataset=None,changes={}):
                     parameters['MODEL_NAME'] = 'EstimatorWord'
                     parameters['EPOCH_PER_MODEL'] = parameters['EPOCH_PER_EST_WORD']
                     parameters['LOSS'] = 'categorical_crossentropy'
-                    if i==0:
+                    if i == 0:
                         trainable_pred = False
 
                 else:
@@ -407,13 +427,14 @@ def main(config=None,dataset=None,changes={}):
                     logging.info('Running training task for ' + parameters['MODEL_NAME'])
                     parameters['MAX_EPOCH'] = parameters['EPOCH_PER_MODEL']
 
-                    train_model(parameters, weights_dict, dataset, trainable_est=trainable_est, trainable_pred=trainable_pred, weights_path=parameters.get('PRED_WEIGHTS', None))
+                    train_model(parameters, weights_dict, dataset, trainable_est=trainable_est,
+                                trainable_pred=trainable_pred, weights_path=parameters.get('PRED_WEIGHTS', None))
 
-                    flag=True
+                    flag = True
     else:
 
         logging.info('Running training task.')
-        train_model(parameters, dataset, trainable_est=True, trainable_pred=True, weights_path=parameters.get('PRED_WEIGHTS', None))
-
+        train_model(parameters, dataset, trainable_est=True, trainable_pred=True,
+                    weights_path=parameters.get('PRED_WEIGHTS', None))
 
     logger.info('Done!')


### PR DESCRIPTION
In order to facilitate using deepquest as either a command line program or as a python module, this PR will move the command line argument handling all to `__main__.py`
They're then formatted into strings, dicts etc. rather than as an argparse.Namespace object to be passed into the deepquest functions.

@fredblain has asked me to also remove the --dataset option, but I'll do this in a separate branch for clarity, so it remains in place for this PR.

I have also removed some redundant imports, added some docstrings etc.

Note:
`deepquest.train.main()` takes its parameters as either: a dictionary of parameters, or a path string to a config yml or pkl.

Further, I've added:
```python
from .train import main as train
from .predict import main as predict
from .score import main as score
```
to `__init__.py` but this is untested at present. The intention here is to run as `deepquest.train()` rather than as `deepquest.train.main()`