### PR TITLE
Record the seed and random states during training

### DIFF
--- a/__main__.py
+++ b/__main__.py
@@ -14,7 +14,7 @@ def train(args):
     elif args.config.endswith('.pkl'):
         parameters = update_parameters(parameters, pkl2dict(args.config))
     parameters.update(changes2dict(args))
-    if parameters['SEED']:
+    if parameters.get('SEED') is not None:
         print('Setting deepQuest seed to', parameters['SEED'])
         import numpy.random
         numpy.random.seed(parameters['SEED'])

--- a/train.py
+++ b/train.py
@@ -293,7 +293,8 @@ def buildCallbacks(params, model, dataset):
 
     return callbacks
 
-def save_random_states(write_path,user_seed=None):
+
+def save_random_states(write_path, user_seed=None):
     import numpy.random
     import random
     import pickle
@@ -302,11 +303,11 @@ def save_random_states(write_path,user_seed=None):
     py_rand_state = random.getstate()
 
     data = {'user_seed': user_seed,
-            'np_rand_state' : np_rand_state,
-            'py_rand_state' : py_rand_state
+            'np_rand_state': np_rand_state,
+            'py_rand_state': py_rand_state
             }
 
-    with open(os.path.join(write_path, 'random_states.pkl'),'wb') as outfile:
+    with open(os.path.join(write_path, 'random_states.pkl'), 'wb') as outfile:
         pickle.dump(data, outfile)
 
 

--- a/train.py
+++ b/train.py
@@ -297,18 +297,24 @@ def buildCallbacks(params, model, dataset):
 def save_random_states(write_path, user_seed=None):
     import numpy.random
     import random
-    import pickle
+    import json
 
-    np_rand_state = numpy.random.get_state()
-    py_rand_state = random.getstate()
+    n = numpy.random.get_state()
+    p = random.getstate()
+
+    n = list(numpy.random.get_state())
+    n[1] = n[1].tolist()
+
+    p = list(numpy.random.get_state())
+    p[1] = p[1].tolist()
 
     data = {'user_seed': user_seed,
-            'np_rand_state': np_rand_state,
-            'py_rand_state': py_rand_state
+            'numpy_rand_state': n,
+            'python_rand_state': p
             }
 
-    with open(os.path.join(write_path, 'random_states.pkl'), 'wb') as outfile:
-        pickle.dump(data, outfile)
+    with open(os.path.join(write_path, 'random_states.json'), 'w') as outfile:
+        json.dump(data, outfile)
 
 
 def main(config=None, dataset=None, changes={}):

--- a/train.py
+++ b/train.py
@@ -299,14 +299,11 @@ def save_random_states(write_path, user_seed=None):
     import random
     import json
 
-    n = numpy.random.get_state()
-    p = random.getstate()
-
     n = list(numpy.random.get_state())
     n[1] = n[1].tolist()
 
-    p = list(numpy.random.get_state())
-    p[1] = p[1].tolist()
+    p = list(random.getstate())
+    p[1] = list(p[1])
 
     data = {'user_seed': user_seed,
             'numpy_rand_state': n,

--- a/train.py
+++ b/train.py
@@ -303,7 +303,6 @@ def save_random_states(write_path, user_seed=None):
     n[1] = n[1].tolist()
 
     p = list(random.getstate())
-    p[1] = list(p[1])
 
     data = {'user_seed': user_seed,
             'numpy_rand_state': n,

--- a/train.py
+++ b/train.py
@@ -293,6 +293,21 @@ def buildCallbacks(params, model, dataset):
 
     return callbacks
 
+def log_random_state(write_path,user_seed=None):
+    import numpy.random
+    import random
+    import pickle
+
+    np_rand_state = numpy.random.get_state()
+    py_rand_state = random.getstate()
+
+    data = {'np_rand_state' : np_rand_state,
+            'py_rand_state' : py_rand_state,
+            'user_seed': user_seed}
+
+    with open(os.path.join(write_path, 'random_states.pkl'),'wb') as outfile:
+        pickle.dump(data, outfile)
+
 
 def main(config=None, dataset=None, changes={}):
     """
@@ -373,6 +388,8 @@ def main(config=None, dataset=None, changes={}):
             return
 
     check_params(parameters)
+
+    log_random_state(parameters['STORE_PATH'], user_seed=parameters.get('SEED'))
 
     if parameters['MULTI_TASK']:
 

--- a/train.py
+++ b/train.py
@@ -301,9 +301,10 @@ def save_random_states(write_path,user_seed=None):
     np_rand_state = numpy.random.get_state()
     py_rand_state = random.getstate()
 
-    data = {'np_rand_state' : np_rand_state,
-            'py_rand_state' : py_rand_state,
-            'user_seed': user_seed}
+    data = {'user_seed': user_seed,
+            'np_rand_state' : np_rand_state,
+            'py_rand_state' : py_rand_state
+            }
 
     with open(os.path.join(write_path, 'random_states.pkl'),'wb') as outfile:
         pickle.dump(data, outfile)

--- a/train.py
+++ b/train.py
@@ -293,7 +293,7 @@ def buildCallbacks(params, model, dataset):
 
     return callbacks
 
-def log_random_state(write_path,user_seed=None):
+def save_random_states(write_path,user_seed=None):
     import numpy.random
     import random
     import pickle
@@ -389,7 +389,7 @@ def main(config=None, dataset=None, changes={}):
 
     check_params(parameters)
 
-    log_random_state(parameters['STORE_PATH'], user_seed=parameters.get('SEED'))
+    save_random_states(parameters['STORE_PATH'], user_seed=parameters.get('SEED'))
 
     if parameters['MULTI_TASK']:
 


### PR DESCRIPTION
This PR will:
 - During training record:
   - Record in a pickle file:
     - the seed value set by the user
     - the random state of numpy
     - the random state of python's random
 - Fix a bug in the seed setting routine in `__main__.py` which caused an error if the seed was omitted from the config file or command line.