### PR TITLE
Store the built dataset in trained model directory

### DIFF
--- a/__main__.py
+++ b/__main__.py
@@ -21,7 +21,7 @@ def train(args):
         import random
         random.seed(parameters['SEED'])
     import train
-    train.main(parameters, args.dataset)
+    train.main(parameters)
 
 
 def predict(args):
@@ -72,8 +72,6 @@ if __name__ == "__main__":
     train_parser.set_defaults(func=train)
     train_parser.add_argument("-c", "--config",   required=False,
                               help="Config YAML or pkl for loading the model configuration. ")
-    train_parser.add_argument("-ds", "--dataset", required=False,
-                              help="Optional dataset instance to be trained on. ")
     train_parser.add_argument("changes", nargs="*", help="Changes to config. "
                               "Following the syntax Key=Value",
                               default="")

--- a/configs/default-config-BiRNN.yml
+++ b/configs/default-config-BiRNN.yml
@@ -14,7 +14,6 @@ WORD_QE_CLASSES: 5
 
 DATA_DIR: 'data/'                                  # Data directory
 MODEL_DIRECTORY: 'trained_models/'                # Trained models will be stored here
-DATASET_STORE_PATH: 'datasets/'                   # Dataset instance will be stored here
 
 #EVAL_ON_SETS_KERAS: ['val']                 # Possible values: 'train', 'val' and 'test' (Keras' evaluator). Untested.
 EVAL_ON_SETS_KERAS: []

--- a/dq_tests/test-BiRNNdoc.sh
+++ b/dq_tests/test-BiRNNdoc.sh
@@ -30,7 +30,7 @@ else
   TRAIN_RESULT="passed"
   echo "QE training $TRAIN_RESULT ($level  level BiRNN with $KERAS_BACKEND on $task_name test dataset)"
   EPOCH=$(awk -F, '/pearson/ {M=-1;next};$3>M {M=$3;E=$1};END {print E}' trained_models/${task_name}_srcmt_${model_type}/val.qe_metrics)
-  python __main__.py predict --dataset datasets/Dataset_${task_name}_srcmt.pkl --model trained_models/${model_name}/epoch_${EPOCH}.h5 --save_path saved_predictions/prediction_${task_name}/ --evalset test
+  python __main__.py predict --dataset ${store_path}/Dataset_${task_name}_srcmt.pkl --model trained_models/${model_name}/epoch_${EPOCH}.h5 --save_path saved_predictions/prediction_${task_name}/ --evalset test
   PCC=$(awk -F, '/pearson/ {M=-1;next};$3>M {M=$3};END {print M}' saved_predictions/prediction_${task_name}/test.qe_metrics)
   TESTVAL=$(awk -v backend=$KERAS_BACKEND -v level=${level}Predict -v task_name=$task_name -v metric=$metric -F,\
    'NR==1 {next};$1==backend && $2==level && $3==task_name && $4==metric {M=$5};END {print M}' dq_tests/testVals.csv )

--- a/dq_tests/test-BiRNNsent.sh
+++ b/dq_tests/test-BiRNNsent.sh
@@ -30,7 +30,7 @@ else
   TRAIN_RESULT="passed"
   echo "QE training $TRAIN_RESULT ($level  level BiRNN with $KERAS_BACKEND on $task_name test dataset)"
   EPOCH=$(awk -F, '/pearson/ {M=-1;next};$3>M {M=$3;E=$1};END {print E}' trained_models/${task_name}_srcmt_${model_type}/val.qe_metrics)
-  python __main__.py predict --dataset datasets/Dataset_${task_name}_srcmt.pkl --model trained_models/${model_name}/epoch_${EPOCH}.h5 --save_path saved_predictions/prediction_${task_name}/ --evalset test
+  python __main__.py predict --dataset ${store_path}/Dataset_${task_name}_srcmt.pkl --model trained_models/${model_name}/epoch_${EPOCH}.h5 --save_path saved_predictions/prediction_${task_name}/ --evalset test
   PCC=$(awk -F, '/pearson/ {M=-1;next};$3>M {M=$3};END {print M}' saved_predictions/prediction_${task_name}/test.qe_metrics)
   TESTVAL=$(awk -v backend=$KERAS_BACKEND -v level=${level}Predict -v task_name=$task_name -v metric=$metric -F,\
    'NR==1 {next};$1==backend && $2==level && $3==task_name && $4==metric {M=$5};END {print M}' dq_tests/testVals.csv )

--- a/dq_tests/test-BiRNNword.sh
+++ b/dq_tests/test-BiRNNword.sh
@@ -30,7 +30,7 @@ else
   TRAIN_RESULT="passed"
   echo "QE training $TRAIN_RESULT ($level  level BiRNN with $KERAS_BACKEND on $task_name test dataset)"
   EPOCH=$(awk -F, '/f1_prod/ {M=-1;next};$2>M {M=$2;E=$1};END {print E}' trained_models/${task_name}_srcmt_${model_type}/val.qe_metrics)
-  python __main__.py predict --dataset datasets/Dataset_${task_name}_srcmt.pkl --model trained_models/${model_name}/epoch_${EPOCH}.h5 --save_path saved_predictions/prediction_${task_name}/ --evalset test
+  python __main__.py predict --dataset ${store_path}/Dataset_${task_name}_srcmt.pkl --model trained_models/${model_name}/epoch_${EPOCH}.h5 --save_path saved_predictions/prediction_${task_name}/ --evalset test
   PCC=$(awk -F, '/f1_prod/ {M=-1;next};$2>M {M=$2};END {print M}' saved_predictions/prediction_${task_name}/test.qe_metrics)
   TESTVAL=$(awk -v backend=$KERAS_BACKEND -v level=${level}Predict -v task_name=$task_name -v metric=$metric -F,\
    'NR==1 {next};$1==backend && $2==level && $3==task_name && $4==metric {M=$5};END {print M}' dq_tests/testVals.csv )

--- a/train.py
+++ b/train.py
@@ -388,6 +388,10 @@ def main(config=None, dataset=None, changes={}):
                 raise Exception('Model parameters not equal, can not resume training. ')
             else:
                 logger.info('Resuming training from epoch ' + str(parameters['RELOAD']))
+            
+            # if there is a pre-trained model and dataset is not specified earlier, set the path to load the existing dataset
+            if dataset == None:
+                dataset = parameters['DATASET_STORE_PATH'] + '/Dataset_' + parameters['DATASET_NAME'] + '_' + parameters['SRC_LAN'] + parameters['TRG_LAN'] + '.pkl'
         else:
             logger.info(
                 'Previously trained config and new config are the same, specify which epoch to resume training from. ')

--- a/train.py
+++ b/train.py
@@ -348,6 +348,7 @@ def main(config=None, dataset=None, changes={}):
     parameters['MODEL_NAME'] = parameters['TASK_NAME'] + '_' + \
         parameters['SRC_LAN'] + parameters['TRG_LAN'] + '_' + parameters['MODEL_TYPE']
     parameters['STORE_PATH'] = os.path.join(parameters['MODEL_DIRECTORY'], parameters['MODEL_NAME'])
+    parameters['DATASET_STORE_PATH'] = parameters['STORE_PATH']
 
     print(parameters)
     logger.info(parameters)

--- a/train.py
+++ b/train.py
@@ -294,7 +294,6 @@ def buildCallbacks(params, model, dataset):
 
     return callbacks
 
-
 def save_random_states(write_path, user_seed=None):
     import numpy.random
     import random
@@ -313,8 +312,7 @@ def save_random_states(write_path, user_seed=None):
     with open(os.path.join(write_path, 'random_states.json'), 'w') as outfile:
         json.dump(data, outfile)
 
-
-def main(config=None, dataset=None, changes={}):
+def main(config=None, changes={}):
     """
     Handles QE model training.
     :param config: Either a path to a YAML or pkl config file or a dictionary of parameters.
@@ -359,6 +357,7 @@ def main(config=None, dataset=None, changes={}):
         # write out initial parameters to pkl
         os.makedirs(parameters['STORE_PATH'])
         dict2pkl(parameters, os.path.join(parameters['STORE_PATH'], 'config_init.pkl'))
+        dataset=None
     else:
         # if model already exists check that only RELOAD or RELOAD_EPOCH differ
         logger.info('Model ' + parameters['STORE_PATH'] + ' already exists. ')
@@ -388,10 +387,9 @@ def main(config=None, dataset=None, changes={}):
                 raise Exception('Model parameters not equal, can not resume training. ')
             else:
                 logger.info('Resuming training from epoch ' + str(parameters['RELOAD']))
-            
+
             # if there is a pre-trained model and dataset is not specified earlier, set the path to load the existing dataset
-            if dataset == None:
-                dataset = parameters['DATASET_STORE_PATH'] + '/Dataset_' + parameters['DATASET_NAME'] + '_' + parameters['SRC_LAN'] + parameters['TRG_LAN'] + '.pkl'
+            dataset = parameters['DATASET_STORE_PATH'] + '/Dataset_' + parameters['DATASET_NAME'] + '_' + parameters['SRC_LAN'] + parameters['TRG_LAN'] + '.pkl'
         else:
             logger.info(
                 'Previously trained config and new config are the same, specify which epoch to resume training from. ')

--- a/train.py
+++ b/train.py
@@ -9,6 +9,7 @@ import yaml
 
 from keras_wrapper.extra.read_write import pkl2dict, dict2pkl
 from keras_wrapper.cnn_model import updateModel
+from keras_wrapper.dataset import loadDataset, saveDataset
 from keras.utils import CustomObjectScope
 from utils.utils import update_parameters
 from data_engine.prepare_data import build_dataset, update_dataset_from_file, keep_n_captions


### PR DESCRIPTION
This PR will:
 - Store the built dataset in trained model directory via setting the `DATASET_STORE_PATH` to the same as `STORE_PATH`. This is just to make it obvious which dataset was used to train which model.
 - Remove the command line option to pass in a dataset as per @fredblain's request
 - Update the tests to take account of this.