### PR TITLE
Improvements to command line interface

### DIFF
--- a/deepquest/__init__.py
+++ b/deepquest/__init__.py
@@ -1,3 +1,7 @@
-from .train import main as train
-from .predict import main as predict
-from .score import main as score
+import warnings
+warnings.filterwarnings('ignore',category=FutureWarning)
+# Used to suppress numpy FutureWarnings, turn off in developer mode
+
+from deepquest.train import main as train
+from deepquest.predict import main as predict
+from deepquest.score import main as score

--- a/deepquest/__init__.py
+++ b/deepquest/__init__.py
@@ -1,7 +1,29 @@
-import warnings
-warnings.filterwarnings('ignore',category=FutureWarning)
-# Used to suppress numpy FutureWarnings, turn off in developer mode
+def train(config=None, changes={}):
+    """
+    Handles QE model training.
+    :param config: Either a path to a YAML or pkl config file or a dictionary of parameters.
+    :param dataset: Optional path to a previously built pkl dataset.
+    :param changes: Optional dictionary of parameters to overwrite config.
+    """
+    import deepquest.train
+    train.main(config, changes)
 
-from deepquest.train import main as train
-from deepquest.predict import main as predict
-from deepquest.score import main as score
+def predict(model, dataset, save_path=None, evalset=None, changes={}):
+    """
+    Predicts QE scores on a dataset using a pre-trained model.
+    :param model: Model file (.h5) to use.
+    :param dataset: Dataset file (.pkl) to use.
+    :param save_path: Optinal directory path to save predictions to. Default = STORE_PATH
+    :param evalset: Optional set to evaluate on. Default = 'test'
+    :param changes: Optional dictionary of parameters to overwrite config.
+    """
+    import deepquest.predict
+    predict.main(model, dataset, save_path, evalset, changes)
+
+def score(files):
+    """
+    Evaluate a set of predictions with regard to a reference set.
+    :param files: List of paths to two text files containing predictions and references.
+    """
+    import deepquest.score
+    score.main(files)

--- a/deepquest/__main__.py
+++ b/deepquest/__main__.py
@@ -104,8 +104,6 @@ def main():
 
     args = parser.parse_args()
 
-    print(sys.argv)
-
     if (not hasattr(args,'func')) or (len(sys.argv) == 1):
         parser.print_help()
     elif hasattr(args, 'func') and (len(sys.argv) == 2):

--- a/deepquest/__main__.py
+++ b/deepquest/__main__.py
@@ -72,6 +72,7 @@ def main():
     # parser for training
     train_parser = subparsers.add_parser('train', help='Train QE models')
     train_parser.set_defaults(func=train)
+    train_parser.add_argument("help", nargs='?', help="Show the help information.")
     train_parser.add_argument("-c", "--config",   required=False,
                               help="Config YAML or pkl for loading the model configuration. ")
     train_parser.add_argument("changes", nargs="*", help="Changes to config. "
@@ -81,9 +82,10 @@ def main():
     # parser for prediction
     predict_parser = subparsers.add_parser('predict', help='Sample using trained QE models')
     predict_parser.set_defaults(func=predict)
-    predict_parser.add_argument("--model", required=True,
+    predict_parser.add_argument("help", nargs='?', help="Show the help information.")
+    predict_parser.add_argument("--model", required=False,
                                 help="model file (.h5) to use")
-    predict_parser.add_argument("--dataset", required=True,
+    predict_parser.add_argument("--dataset", required=False,
                                 help="dataset file (.pkl) to use")
     predict_parser.add_argument("--save_path", required=False, help="Directory path to save predictions to. "
                                 "If not specified, defaults to STORE_PATH")
@@ -96,15 +98,23 @@ def main():
     # parser for scoring
     score_parser = subparsers.add_parser(
         'score', help='Evaluate a set of predictions with regard to a reference set. ')
+    score_parser.add_argument("help", nargs='?', help="Show the help information.")
     score_parser.set_defaults(func=score)
-    score_parser.add_argument(
-        "files", nargs=2, help="Two text files containing predictions and references. ")
+    score_parser.add_argument("files", nargs="*", help="Two text files containing predictions and references. ", default="")
 
     args = parser.parse_args()
+
+    print(sys.argv)
+
     if (not hasattr(args,'func')) or (len(sys.argv) == 1):
         parser.print_help()
-    elif hasattr(args,'func') and (len(sys.argv) == 2):
+    elif hasattr(args, 'func') and (len(sys.argv) == 2):
         parser.print_help()
+    elif hasattr(args, 'func') and 'help' in sys.argv:
+        parsers = {'train': train_parser,
+                   'predict': predict_parser,
+                   'score': score_parser}
+        parsers[str(args.func.__name__)].print_help()
     else:
         args.func(args)
     sys.exit(0)

--- a/deepquest/__main__.py
+++ b/deepquest/__main__.py
@@ -65,6 +65,10 @@ def main():
                                     description='A framework for neural-based quality estimation.')
     subparsers = parser.add_subparsers(help='mode of operation')
 
+    # parser for help text
+    help_parser = subparsers.add_parser('help', help='Show the help text')
+    help_parser.set_defaults(func=help)
+
     # parser for training
     train_parser = subparsers.add_parser('train', help='Train QE models')
     train_parser.set_defaults(func=train)


### PR DESCRIPTION
 - Following @fredblain's request for command line commands à la `dq help` or `dq train help` to work analogously to `dq --help`, `dq -h` or `dq train --help`.

 - Also, have suppressed some numpy warnings in `deepquest/__init__.py` so that they don't appear at the top of running the CLI when typing `dq help` or something.

 - Via this, have discovered that because of `deepquest/__init__.py` which looks like:
```python
from deepquest.train import main as train
from deepquest.predict import main as predict
from deepquest.score import main as score
```
 all of train, predict and score are imported every time deepquest is run. These commands are done in order to tidy up the module naming for running as a python module so we have `dq.train()` instead of `dq.train.main()` for instance.

Any suggestions as to how to clean this up gratefully received. Short of moving all of the functions into one file again..