### PR TITLE
Redesign of logging

### DIFF
--- a/deepquest/predict.py
+++ b/deepquest/predict.py
@@ -12,10 +12,9 @@ import deepquest.qe_models as modFactory
 from deepquest.utils.prepare_data import build_dataset, update_dataset_from_file, keep_n_captions
 from deepquest.utils import evaluation
 from deepquest.utils.callbacks import *
+from deepquest.utils.logs import logger_setup
 
-logging.basicConfig(level=logging.DEBUG,
-                    format='[%(asctime)s] %(message)s', datefmt='%d/%m/%Y %H:%M:%S')
-logger = logging.getLogger(__name__)
+logger, logging = logger_setup('predict')
 
 
 def apply_NMT_model(params, dataset, model, save_path):

--- a/deepquest/score.py
+++ b/deepquest/score.py
@@ -4,10 +4,9 @@ import sys
 import scipy.stats
 import sklearn.metrics
 from math import sqrt
+from deepquest.utils.logs import logger_setup
 
-logging.basicConfig(level=logging.INFO,
-                    format='[%(asctime)s] %(message)s', datefmt='%d/%m/%Y %H:%M:%S')
-logger = logging.getLogger(__name__)
+logger, logging = logger_setup('score')
 
 
 def read_file_to_list(file_in, logger):

--- a/deepquest/train.py
+++ b/deepquest/train.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 from __future__ import print_function
 import ast
-import logging
 import os
 
 from timeit import default_timer as timer
@@ -17,12 +16,9 @@ from nmt_keras.utils.utils import update_parameters
 import deepquest.qe_models as modFactory
 from deepquest.utils.callbacks import PrintPerformanceMetricOnEpochEndOrEachNUpdates
 from deepquest.utils.prepare_data import build_dataset, update_dataset_from_file, keep_n_captions, preprocessDoc
+from deepquest.utils.logs import logger_setup
 
-logging.basicConfig(level=logging.INFO,
-                    format='[%(asctime)s] %(message)s', datefmt='%d/%m/%Y %H:%M:%S')
-
-logger = logging.getLogger(__name__)
-
+logger, logging = logger_setup('train')
 
 def train_model(params, weights_dict, load_dataset=None, trainable_pred=True, trainable_est=True, weights_path=None):
     """

--- a/deepquest/utils/logs.py
+++ b/deepquest/utils/logs.py
@@ -1,0 +1,26 @@
+import logging
+import os
+import time
+
+
+def logger_setup(mode):
+    """
+    Set up deepquest logs.
+    :param mode: Mode of operation to be appended to log file name (string)
+    :return: logger and logging objects
+    """
+    logFileName = 'logs/%s-deepquest-%s.log' % (time.strftime("%Y-%m-%d-%H-%M-%S"), mode)
+    if not os.path.exists(os.path.dirname(logFileName)):
+        os.makedirs(os.path.dirname(logFileName))
+    logging.basicConfig(level=logging.INFO)
+    fileh = logging.FileHandler(logFileName, 'w')
+    formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+    fileh.setFormatter(formatter)
+
+    logger = logging.getLogger()  # root logger
+    for hdlr in logger.handlers[:]:  # remove all old handlers
+        logger.removeHandler(hdlr)
+    logger.addHandler(fileh)      # set the new handler
+    logger.addHandler(logging.StreamHandler())
+
+    return logger, logging

--- a/tests/test-BiRNNdoc.sh
+++ b/tests/test-BiRNNdoc.sh
@@ -14,34 +14,34 @@ metric=pearson
 TESTVAL=$(awk -v backend=$KERAS_BACKEND -v level=$level -v task_name=$task_name -v metric=$metric -F,\
  'NR==1 {next};$1==backend && $2==level && $3==task_name && $4==metric {M=$5};END {print M}' tests/testVals.csv )
 
-python tests/getTestData_BiRNNdoc.py
+python tests/getTestData_BiRNNdoc.py | tee -a testlog-${model_name}-test.txt
 
-python tests/test.py train -c ${conf} TASK_NAME=$task_name DATASET_NAME=$task_name MODEL_TYPE=$model_type MODEL_NAME=$model_name || true > log-${model_name}-test.txt
+python tests/test.py train -c ${conf} TASK_NAME=$task_name DATASET_NAME=$task_name MODEL_TYPE=$model_type MODEL_NAME=$model_name | tee -a testlog-${model_name}-test.txt 2>&1 || true
 
 PCC=$(awk -F, '/pearson/ {M=-1;next};$3>M {M=$3};END {print M}' trained_models/${task_name}_srcmt_${model_type}/val.qe_metrics)
 
-echo "PCC test value was $PCC tested against $TESTVAL"
+echo "PCC test value was $PCC tested against $TESTVAL" | tee -a testlog-${model_name}-test.txt
 
 if echo $PCC $TESTVAL | awk '{exit ($1-$2)^2<1E-12}'; then
   TRAIN_RESULT="failed"
-  echo "QE training $TRAIN_RESULT ($level  level BiRNN with $KERAS_BACKEND on $task_name test dataset)"
+  echo "QE training $TRAIN_RESULT ($level  level BiRNN with $KERAS_BACKEND on $task_name test dataset)" | tee -a testlog-${model_name}-test.txt
   exit 1
 else
   TRAIN_RESULT="passed"
-  echo "QE training $TRAIN_RESULT ($level  level BiRNN with $KERAS_BACKEND on $task_name test dataset)"
+  echo "QE training $TRAIN_RESULT ($level  level BiRNN with $KERAS_BACKEND on $task_name test dataset)" | tee -a testlog-${model_name}-test.txt
   EPOCH=$(awk -F, '/pearson/ {M=-1;next};$3>M {M=$3;E=$1};END {print E}' trained_models/${task_name}_srcmt_${model_type}/val.qe_metrics)
-  python tests/test.py predict --dataset ${store_path}/Dataset_${task_name}_srcmt.pkl --model trained_models/${model_name}/epoch_${EPOCH}.h5 --save_path saved_predictions/prediction_${task_name}/ --evalset test
+  python tests/test.py predict --dataset ${store_path}/Dataset_${task_name}_srcmt.pkl --model trained_models/${model_name}/epoch_${EPOCH}.h5 --save_path saved_predictions/prediction_${task_name}/ --evalset test | tee -a testlog-${model_name}-test.txt 2>&1
   PCC=$(awk -F, '/pearson/ {M=-1;next};$3>M {M=$3};END {print M}' saved_predictions/prediction_${task_name}/test.qe_metrics)
   TESTVAL=$(awk -v backend=$KERAS_BACKEND -v level=${level}Predict -v task_name=$task_name -v metric=$metric -F,\
    'NR==1 {next};$1==backend && $2==level && $3==task_name && $4==metric {M=$5};END {print M}' tests/testVals.csv )
-  echo "PCC test value was $PCC tested against $TESTVAL"
+  echo "PCC test value was $PCC tested against $TESTVAL" | tee -a testlog-${model_name}-test.txt
   if echo $PCC $TESTVAL | awk '{exit ($1-$2)^2<1E-10}'; then
      PREDICT_RESULT="failed"
-     echo "QE prediction $PREDICT_RESULT ($level  level BiRNN with $KERAS_BACKEND on $task_name test dataset)"
+     echo "QE prediction $PREDICT_RESULT ($level  level BiRNN with $KERAS_BACKEND on $task_name test dataset)" | tee -a testlog-${model_name}-test.txt
      exit 1
    else
      PREDICT_RESULT="passed"
-     echo "QE prediction $PREDICT_RESULT ($level  level BiRNN with $KERAS_BACKEND on $task_name test dataset)"
+     echo "QE prediction $PREDICT_RESULT ($level  level BiRNN with $KERAS_BACKEND on $task_name test dataset)" | tee -a testlog-${model_name}-test.txt
      exit 0
    fi
 fi

--- a/tests/test-BiRNNsent.sh
+++ b/tests/test-BiRNNsent.sh
@@ -14,34 +14,34 @@ metric=pearson
 TESTVAL=$(awk -v backend=$KERAS_BACKEND -v level=$level -v task_name=$task_name -v metric=$metric -F,\
  'NR==1 {next};$1==backend && $2==level && $3==task_name && $4==metric {M=$5};END {print M}' tests/testVals.csv )
 
-python tests/getTestData_BiRNNsent.py
+python tests/getTestData_BiRNNsent.py | tee -a testlog-${model_name}-test.txt
 
-python tests/test.py train -c ${conf} TASK_NAME=$task_name DATASET_NAME=$task_name MODEL_TYPE=$model_type MODEL_NAME=$model_name || true > log-${model_name}-test.txt
+python tests/test.py train -c ${conf} TASK_NAME=$task_name DATASET_NAME=$task_name MODEL_TYPE=$model_type MODEL_NAME=$model_name | tee -a testlog-${model_name}-test.txt  2>&1 || true
 
 PCC=$(awk -F, '/pearson/ {M=-1;next};$3>M {M=$3};END {print M}' trained_models/${task_name}_srcmt_${model_type}/val.qe_metrics)
 
-echo "PCC test value was $PCC tested against $TESTVAL"
+echo "PCC test value was $PCC tested against $TESTVAL" | tee -a testlog-${model_name}-test.txt
 
 if echo $PCC $TESTVAL | awk '{exit ($1-$2)^2<1E-12}'; then
   TRAIN_RESULT="failed"
-  echo "QE training $TRAIN_RESULT ($level  level BiRNN with $KERAS_BACKEND on $task_name test dataset)"
+  echo "QE training $TRAIN_RESULT ($level  level BiRNN with $KERAS_BACKEND on $task_name test dataset)" | tee -a testlog-${model_name}-test.txt
   exit 1
 else
   TRAIN_RESULT="passed"
-  echo "QE training $TRAIN_RESULT ($level  level BiRNN with $KERAS_BACKEND on $task_name test dataset)"
+  echo "QE training $TRAIN_RESULT ($level  level BiRNN with $KERAS_BACKEND on $task_name test dataset)" | tee -a testlog-${model_name}-test.txt
   EPOCH=$(awk -F, '/pearson/ {M=-1;next};$3>M {M=$3;E=$1};END {print E}' trained_models/${task_name}_srcmt_${model_type}/val.qe_metrics)
-  python tests/test.py predict --dataset ${store_path}/Dataset_${task_name}_srcmt.pkl --model trained_models/${model_name}/epoch_${EPOCH}.h5 --save_path saved_predictions/prediction_${task_name}/ --evalset test
+  python tests/test.py predict --dataset ${store_path}/Dataset_${task_name}_srcmt.pkl --model trained_models/${model_name}/epoch_${EPOCH}.h5 --save_path saved_predictions/prediction_${task_name}/ --evalset test  | tee -a testlog-${model_name}-test.txt  2>&1
   PCC=$(awk -F, '/pearson/ {M=-1;next};$3>M {M=$3};END {print M}' saved_predictions/prediction_${task_name}/test.qe_metrics)
   TESTVAL=$(awk -v backend=$KERAS_BACKEND -v level=${level}Predict -v task_name=$task_name -v metric=$metric -F,\
    'NR==1 {next};$1==backend && $2==level && $3==task_name && $4==metric {M=$5};END {print M}' tests/testVals.csv )
-  echo "PCC test value was $PCC tested against $TESTVAL"
+  echo "PCC test value was $PCC tested against $TESTVAL" | tee -a testlog-${model_name}-test.txt
   if echo $PCC $TESTVAL | awk '{exit ($1-$2)^2<1E-12}'; then
      PREDICT_RESULT="failed"
-     echo "QE prediction $PREDICT_RESULT ($level  level BiRNN with $KERAS_BACKEND on $task_name test dataset)"
+     echo "QE prediction $PREDICT_RESULT ($level  level BiRNN with $KERAS_BACKEND on $task_name test dataset)" | tee -a testlog-${model_name}-test.txt
      exit 1
    else
      PREDICT_RESULT="passed"
-     echo "QE prediction $PREDICT_RESULT ($level  level BiRNN with $KERAS_BACKEND on $task_name test dataset)"
+     echo "QE prediction $PREDICT_RESULT ($level  level BiRNN with $KERAS_BACKEND on $task_name test dataset)" | tee -a testlog-${model_name}-test.txt
      exit 0
    fi
 fi

--- a/tests/test-BiRNNword.sh
+++ b/tests/test-BiRNNword.sh
@@ -14,34 +14,34 @@ metric=f1_prod
 TESTVAL=$(awk -v backend=$KERAS_BACKEND -v level=$level -v task_name=$task_name -v metric=$metric -F,\
  'NR==1 {next};$1==backend && $2==level && $3==task_name && $4==metric {M=$5};END {print M}' tests/testVals.csv )
 
-python tests/getTestData_BiRNNword.py
+python tests/getTestData_BiRNNword.py | tee -a testlog-${model_name}-test.txt
 
-python tests/test.py train -c ${conf} TASK_NAME=$task_name DATASET_NAME=$task_name MODEL_TYPE=$model_type MODEL_NAME=$model_name || true > log-${model_name}-test.txt
+python tests/test.py train -c ${conf} TASK_NAME=$task_name DATASET_NAME=$task_name MODEL_TYPE=$model_type MODEL_NAME=$model_name | tee -a testlog-${model_name}-test.txt  2>&1  || true
 
 PCC=$(awk -F, '/f1_prod/ {M=-1;next};$2>M {M=$2};END {print M}' trained_models/${task_name}_srcmt_${model_type}/val.qe_metrics)
 
-echo "PCC test value was $PCC tested against $TESTVAL"
+echo "PCC test value was $PCC tested against $TESTVAL" | tee -a testlog-${model_name}-test.txt
 
 if echo $PCC $TESTVAL | awk '{exit ($1-$2)^2<1E-12}'; then
   TRAIN_RESULT="failed"
-  echo "QE training $TRAIN_RESULT ($level  level BiRNN with $KERAS_BACKEND on $task_name test dataset)"
+  echo "QE training $TRAIN_RESULT ($level  level BiRNN with $KERAS_BACKEND on $task_name test dataset)" | tee -a testlog-${model_name}-test.txt
   exit 1
 else
   TRAIN_RESULT="passed"
-  echo "QE training $TRAIN_RESULT ($level  level BiRNN with $KERAS_BACKEND on $task_name test dataset)"
+  echo "QE training $TRAIN_RESULT ($level  level BiRNN with $KERAS_BACKEND on $task_name test dataset)" | tee -a testlog-${model_name}-test.txt
   EPOCH=$(awk -F, '/f1_prod/ {M=-1;next};$2>M {M=$2;E=$1};END {print E}' trained_models/${task_name}_srcmt_${model_type}/val.qe_metrics)
-  python tests/test.py predict --dataset ${store_path}/Dataset_${task_name}_srcmt.pkl --model trained_models/${model_name}/epoch_${EPOCH}.h5 --save_path saved_predictions/prediction_${task_name}/ --evalset test
+  python tests/test.py predict --dataset ${store_path}/Dataset_${task_name}_srcmt.pkl --model trained_models/${model_name}/epoch_${EPOCH}.h5 --save_path saved_predictions/prediction_${task_name}/ --evalset test | tee -a testlog-${model_name}-test.txt 2>&1
   PCC=$(awk -F, '/f1_prod/ {M=-1;next};$2>M {M=$2};END {print M}' saved_predictions/prediction_${task_name}/test.qe_metrics)
   TESTVAL=$(awk -v backend=$KERAS_BACKEND -v level=${level}Predict -v task_name=$task_name -v metric=$metric -F,\
    'NR==1 {next};$1==backend && $2==level && $3==task_name && $4==metric {M=$5};END {print M}' tests/testVals.csv )
-  echo "PCC test value was $PCC tested against $TESTVAL"
+  echo "PCC test value was $PCC tested against $TESTVAL" | tee -a testlog-${model_name}-test.txt
   if echo $PCC $TESTVAL | awk '{exit ($1-$2)^2<1E-12}'; then
      PREDICT_RESULT="failed"
-     echo "QE prediction $PREDICT_RESULT ($level  level BiRNN with $KERAS_BACKEND on $task_name test dataset)"
+     echo "QE prediction $PREDICT_RESULT ($level  level BiRNN with $KERAS_BACKEND on $task_name test dataset)" | tee -a testlog-${model_name}-test.txt
      exit 1
    else
      PREDICT_RESULT="passed"
-     echo "QE prediction $PREDICT_RESULT ($level  level BiRNN with $KERAS_BACKEND on $task_name test dataset)"
+     echo "QE prediction $PREDICT_RESULT ($level  level BiRNN with $KERAS_BACKEND on $task_name test dataset)" | tee -a testlog-${model_name}-test.txt
      exit 0
    fi
 fi


### PR DESCRIPTION
@fredblain pointed out that logs were not being written to file here:https://github.com/RSE-Sheffield/deepquest/issues/43#issuecomment-584784247

Logging wasn't working for two reasons:

1. For tests, run from the shell scripts, messages were being incorrectly routed to the logs, so that is now fixed.
Test logs are specifically written out as a file called logtest-MODELNAME.txt with all information on what's happening and whether tests have passed etc.
See commit: 2d91c0a69bfb8d497f853a5f03b720d60da1edc7

2. The nmt-keras logger object was preventing deepquest from creating and configuring a new one. So I have fixed this and moved all of that code to `deepquest.utils.logs.logger_setup()` so a `.log` file is written out to a `/logs/` directory every time that `train()`, `predict()` or `score()` are run.
See commit: abd43bdbd2789d3e5b5efe0299421caf57897c19

Please give this a test and let me know any changes you would make, I'm something of a noob when it comes to logging so let me know how this can be improved.