### PR TITLE
Remove NMT-Keras entirely

### DIFF
--- a/deepquest/predict.py
+++ b/deepquest/predict.py
@@ -234,9 +234,9 @@ def main(model, dataset, save_path=None, evalset=None, changes={}):
 
     logging.info('Running prediction.')
 
-    # NMT Keras expects model path to appear without the .h5
     if model.endswith(".h5"):
         model = model[:-3]
+
     # Directory containing model
     model_dir, file_name = os.path.split(model)
     _, parameters["MODEL_NAME"] = os.path.split(model_dir)
@@ -245,7 +245,6 @@ def main(model, dataset, save_path=None, evalset=None, changes={}):
     assert file_name.startswith("epoch_")
     parameters["RELOAD"] = file_name.replace("epoch_", "")
 
-    # from nmt_keras import model_zoo
     from keras.utils import CustomObjectScope
     import deepquest.qe_models.utils as layers  # includes all layers and everything defined in deepquest.qe_models.utils
     with CustomObjectScope(vars(layers)):

--- a/deepquest/train.py
+++ b/deepquest/train.py
@@ -11,11 +11,10 @@ from keras.utils import CustomObjectScope
 from keras_wrapper.cnn_model import updateModel
 from keras_wrapper.dataset import loadDataset, saveDataset
 from keras_wrapper.extra.read_write import pkl2dict, dict2pkl
-from nmt_keras.nmt_keras import check_params
-from nmt_keras.utils.utils import update_parameters
 
 import deepquest.qe_models as modFactory
 from deepquest.utils.callbacks import PrintPerformanceMetricOnEpochEndOrEachNUpdates
+from deepquest.utils import check_params, update_parameters
 from deepquest.utils.prepare_data import build_dataset, update_dataset_from_file, keep_n_captions, preprocessDoc
 
 logging.basicConfig(level=logging.INFO,
@@ -98,20 +97,6 @@ def train_model(params, weights_dict, load_dataset=None, trainable_pred=True, tr
 
     # Build model
     try:
-        # mf = QEModelFactory()
-        # qe_model = QEModelFactory(params['MODEL_TYPE'], 'sentence'))
-        # FIXME: change 'nmt_keras' for 'quest'
-        # model_obj = getattr(importlib.import_module("nmt_keras.models.{}".format(params['MODEL_TYPE'].lower())))
-
-        # qe_model = model_obj(params,
-        #         model_type=params['MODEL_TYPE'],
-        #         verbose=params['VERBOSE'],
-        #         model_name=params['MODEL_NAME'],
-        #         vocabularies=dataset.vocabulary,
-        #         store_path=params['STORE_PATH'],
-        #         clear_dirs=True,
-        #         weights_path=weights_path)
-        # model_obj = getattr(importlib.import_module("nmt_keras.models.{}".format(params['MODEL_TYPE'].lower())))
         qe_model = modFactory.get(params['MODEL_TYPE'], params)
 
         # Define the inputs and outputs mapping from our Dataset instance to our model

--- a/deepquest/utils/__init__.py
+++ b/deepquest/utils/__init__.py
@@ -1,0 +1,78 @@
+import logging
+logging.basicConfig(level=logging.INFO, format='[%(asctime)s] %(message)s', datefmt='%d/%m/%Y %H:%M:%S')
+logger = logging.getLogger(__name__)
+
+
+def check_params(params):
+    """
+    Checks some typical parameters and warns if something wrong was specified.
+    :param params: Model instance on which to apply the callback.
+    :return: None
+    """
+
+    if params['SRC_PRETRAINED_VECTORS'] and params['SRC_PRETRAINED_VECTORS'][-4:] != '.npy':
+        logger.warn('It seems that the pretrained word vectors provided for the target text are not in npy format.'
+                    'You should preprocess the word embeddings with the "utils/preprocess_*_word_vectors.py script.')
+
+    if params['TRG_PRETRAINED_VECTORS'] and params['TRG_PRETRAINED_VECTORS'][-4:] != '.npy':
+        logger.warn('It seems that the pretrained word vectors provided for the target text are not in npy format.'
+                    'You should preprocess the word embeddings with the "utils/preprocess_*_word_vectors.py script.')
+    if not params['PAD_ON_BATCH']:
+        logger.warn('It is HIGHLY recommended to set the option "PAD_ON_BATCH = True."')
+
+    if params['MODEL_TYPE'].lower() == 'transformer':
+
+        assert params['MODEL_SIZE'] == params['TARGET_TEXT_EMBEDDING_SIZE'], 'When using the Transformer model, ' \
+                                                                             'dimensions of "MODEL_SIZE" and "TARGET_TEXT_EMBEDDING_SIZE" must match. ' \
+                                                                             'Currently, they are: %d and %d, respectively.' % (params['MODEL_SIZE'], params['TARGET_TEXT_EMBEDDING_SIZE'])
+        assert params['MODEL_SIZE'] == params['SOURCE_TEXT_EMBEDDING_SIZE'], 'When using the Transformer model, ' \
+                                                                             'dimensions of "MODEL_SIZE" and "SOURCE_TEXT_EMBEDDING_SIZE" must match. ' \
+                                                                             'Currently, they are: %d and %d, respectively.' % (params['MODEL_SIZE'], params['SOURCE_TEXT_EMBEDDING_SIZE'])
+
+        if params['POS_UNK']:
+            logger.warn('The "POS_UNK" option is still unimplemented for the "Transformer" model. Setting it to False.')
+            params['POS_UNK'] = False
+        assert params['MODEL_SIZE'] % params['N_HEADS'] == 0, \
+            '"MODEL_SIZE" should be a multiple of "N_HEADS". ' \
+            'Currently: mod(%d, %d) == %d.' % (params['MODEL_SIZE'], params['N_HEADS'], params['MODEL_SIZE'] % params['N_HEADS'])
+
+    if params['POS_UNK']:
+        if not params['OPTIMIZED_SEARCH']:
+            logger.warn('Unknown words replacement requires to use the optimized search ("OPTIMIZED_SEARCH" parameter). Setting "POS_UNK" to False.')
+            params['POS_UNK'] = False
+
+    if params['COVERAGE_PENALTY']:
+        assert params['OPTIMIZED_SEARCH'], 'The application of "COVERAGE_PENALTY" requires ' \
+                                           'to use the optimized search ("OPTIMIZED_SEARCH" parameter).'
+
+    if 'from_logits' in params.get('LOSS', 'categorical_crossentropy'):
+        if params.get('CLASSIFIER_ACTIVATION', 'softmax'):
+            params['CLASSIFIER_ACTIVATION'] = None
+
+    if params.get('LABEL_SMOOTHING', 0.) and 'sparse' in params.get('LOSS', 'categorical_crossentropy'):
+        logger.warn('Label smoothing with sparse outputs is still unimplemented')
+
+    if params.get('TRAIN_ONLY_LAST_LAYER'):
+        logger.info('Training only last layer.')
+        params['TRAINABLE_ENCODER'] = False
+        params['TRAINABLE_DECODER'] = False
+
+    return params
+
+def update_parameters(params, updates, restrict=False):
+    """
+    Updates the parameters from params with the ones specified in updates
+    :param params: Parameters dictionary to update
+    :param updates: Updater dictionary
+    :param restrict: If True, parameters from the original dict are not overwritten.
+    :return:
+    """
+    from six import iteritems
+
+    for new_param_key, new_param_value in iteritems(updates):
+        if restrict and params.get(new_param_key) is not None:
+            params[new_param_key] = new_param_value
+        else:
+            params[new_param_key] = new_param_value
+
+    return params

--- a/req-travis-pip.txt
+++ b/req-travis-pip.txt
@@ -4,7 +4,6 @@ future
 git+https://github.com/MarcBS/keras.git#egg=keras
 multimodal-keras-wrapper
 git+https://github.com/lvapeab/coco-caption.git#egg=coco-caption
-git+https://github.com/lvapeab/nmt-keras.git#egg=nmt_keras
 flaky
 keras_applications
 keras_preprocessing

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,3 @@ tensorflow<2
 multimodal-keras-wrapper
 git+https://github.com/MarcBS/keras.git#egg=keras
 git+https://github.com/lvapeab/coco-caption.git#egg=coco-caption
-git+https://github.com/lvapeab/nmt-keras.git#egg=nmt_keras

--- a/setup.py
+++ b/setup.py
@@ -23,8 +23,7 @@ setuptools.setup(
         "pyyaml",
         "tensorflow<2.0",
         "multimodal_keras_wrapper",
-        "keras @ https://github.com/MarcBS/keras/archive/master.zip",
-        "nmt_keras @ https://github.com/davidwilby/nmt-keras/archive/setup.zip"
+        "keras @ https://github.com/MarcBS/keras/archive/master.zip"
     ],
     packages=setuptools.find_packages(),
     package_data={


### PR DESCRIPTION
I noticed that deepQuest now only uses two functions from NMT-Keras `check_params()` and `update_parameters()` since we've just followed their system and copied out all the functionality we need.
_Note:_ Other elements of dQ's functionality all come from multimodal Keras wrapper.

This PR just moves those two functions into `deepquest.utils.__init__` and removes NMT-Keras from the requirements.

With this done, we only have one URL dependency left (which is the only thing that I know is preventing upload to PyPI) being `MarcBS/Keras`