### PR TITLE
correct how lower case model names are treated

### DIFF
--- a/deepquest/qe_models/__init__.py
+++ b/deepquest/qe_models/__init__.py
@@ -27,13 +27,25 @@ QE_MODELS = {
 'estimatordoc':     'estimator_doc',
 }
 
+# maps lower-cased model names to model class names
+model_map = {
+'encword':          'EncWord',
+'encsent':          'EncSent',
+'encdoc':           'EncDoc',
+'encdocatt':        'EncDocAtt',
+'Predictor':        'Predictor',
+'estimatorword':    'EtimatorWord',
+'estimatorsent':    'EstimatorSent',
+'estimatordoc':     'EstimatorDoc',
+}
+
 
 import importlib
 
 # QE MODEL FACTORY-like
 def get(model_name, params):
     try:
-        qe_model = getattr(importlib.import_module('deepquest.qe_models.{}'.format(QE_MODELS[model_name.lower()])), model_name.lower())
+        qe_model = getattr(importlib.import_module('deepquest.qe_models.{}'.format(QE_MODELS[model_name.lower()])), model_map[model_name.lower()])
         return qe_model(params)
 
     except ValueError as e:

--- a/deepquest/qe_models/birnn_doc.py
+++ b/deepquest/qe_models/birnn_doc.py
@@ -14,13 +14,13 @@
 #TODO: add a description of the model here.
 """
 
-from .birnn_word import encword
+from .birnn_word import EncWord
 from .utils import *
 from .layers import *
 from keras.models import clone_model
 
 
-class encdoc(encword):
+class EncDoc(EncWord):
 
     def __init__(self, params):
         # define here attributes that are model specific

--- a/deepquest/qe_models/birnn_doc_att.py
+++ b/deepquest/qe_models/birnn_doc_att.py
@@ -14,12 +14,12 @@
 #TODO: add a description of the model here.
 """
 
-from .birnn_doc import encdoc
+from .birnn_doc import EncDoc
 from .utils import *
 from .layers import *
 
 
-class encdocatt(encdoc):
+class EncDocAtt(EncDoc):
 
     def __init__(self, params):
         # define here attributes that are model specific

--- a/deepquest/qe_models/birnn_sent.py
+++ b/deepquest/qe_models/birnn_sent.py
@@ -14,12 +14,12 @@
 #TODO: add a description of the model here.
 """
 
-from .birnn_word import encword
+from .birnn_word import EncWord
 from .utils import *
 from .layers import *
 
 
-class encsent(encword):
+class EncSent(EncWord):
 
     def __init__(self, params):
         # define here attributes that are model specific

--- a/deepquest/qe_models/birnn_word.py
+++ b/deepquest/qe_models/birnn_word.py
@@ -18,7 +18,7 @@ from .model import QEModel
 from .utils import *
 from .layers import *
 
-class encword(QEModel):
+class EncWord(QEModel):
 
     def __init__(self, params):
         # define here attributes that are model specific

--- a/deepquest/qe_models/estimator_sent.py
+++ b/deepquest/qe_models/estimator_sent.py
@@ -33,12 +33,12 @@
 
 """
 
-from .estimator_word import estimatorword
+from .estimator_word import EstimatorWord
 from .utils import *
 from .layers import *
 
 
-class estimatorsent(estimatorword):
+class EstimatorSent(estimatorWord):
 
     def __init__(self, params, model_type='EstimatorSent',
             verbose=1, structure_path=None, weights_path=None,

--- a/deepquest/qe_models/estimator_word.py
+++ b/deepquest/qe_models/estimator_word.py
@@ -37,7 +37,7 @@ from .utils import *
 from .layers import *
 
 
-class estimatorword(QEModel):
+class EstimatorWord(QEModel):
 
     def __init__(self, params, model_type='EstimatorWord',
             verbose=1, structure_path=None, weights_path=None,

--- a/deepquest/qe_models/predictor.py
+++ b/deepquest/qe_models/predictor.py
@@ -33,7 +33,7 @@ from .utils import *
 from .layers import *
 
 
-class predictor(QEModel):
+class Predictor(QEModel):
 
     def __init__(self, params):
         # define here attributes that are model specific


### PR DESCRIPTION
As @fredblain pointed out b2efca7 contravenes the python style guide for class names to use camel case. This PR corrects that by way of using a dictionary to map between lower-cased model names as specified in the config to class names in camel case.