### PR TITLE
Allow training and prediction at word-level w/ BERT pretrained rep

### DIFF
--- a/deepquest/data_engine/tokenizers.py
+++ b/deepquest/data_engine/tokenizers.py
@@ -170,7 +170,8 @@ class FullTokenizer(object):
 
   def tokenize(self, text):
     split_tokens = []
-    for token in self.basic_tokenizer.tokenize(text):
+    # for token in self.basic_tokenizer.tokenize(text):
+    for token in whitespace_tokenize(text):
       for sub_token in self.wordpiece_tokenizer.tokenize(token):
         split_tokens.append(sub_token)
 

--- a/deepquest/qe_models/layers.py
+++ b/deepquest/qe_models/layers.py
@@ -151,7 +151,13 @@ class BertLayer(Layer):
 
     def compute_output_shape(self, input_shape):
         if self.pooling == None:
-            return (None, self.max_seq_len, 768)
+            # commented out as it would fails to initialise
+            # the output shape properly when reloading the model
+            # with BertLayer as a CustomObject (i.e. would use the
+            # default value given as positional argument to the init()
+            # function).
+            # return (None, self.max_seq_len, 768)
+            return (None, input_shape[0][1], 768)
         else: #'mean' and 'cls'
             return (None, 768)
 


### PR DESCRIPTION
This PR contains modifications to allow the training of word-level BERT-BiRNN QE models.
It also contains modifications to allow reusing/reloading such (pretrained) models to predict on unseen data, similarly to word-level BiRNN, sentence-level BiRNN and sentence-level BERT-BiRNN.
This PR is also compatible with `dq-server` pushed yesterday.

In terms of issues, this PR should allow to:
- close [Predict does not work](https://github.com/RSE-Sheffield/deepquest/issues/53)
- close [Integrate Bert layer into new codebase](https://github.com/RSE-Sheffield/deepquest/issues/43)
- close [Refactor Predict.py](https://github.com/RSE-Sheffield/deepquest/issues/40)